### PR TITLE
[CORE-1] Add login and refresh token endpoint

### DIFF
--- a/main.tsp
+++ b/main.tsp
@@ -1,6 +1,7 @@
 import "@typespec/http";
 import "@typespec/versioning";
 import "./service/healthz.tsp";
+import "./service/auth.tsp";
 
 using Http;
 using Versioning;

--- a/service/auth.tsp
+++ b/service/auth.tsp
@@ -3,7 +3,7 @@ import "@typespec/http";
 using Http;
 
 @tag("Auth")
-namespace Clustron.Auth {
+namespace CoreSystem.Auth {
   enum OAuthProviders {
     google: "google",
   }

--- a/service/auth.tsp
+++ b/service/auth.tsp
@@ -1,0 +1,54 @@
+import "@typespec/http";
+
+using Http;
+
+@tag("Auth")
+namespace Clustron.Auth {
+  enum OAuthProviders {
+    google: "google",
+  }
+
+  model RefreshToken {
+    @doc("The access token and formatted as JWT")
+    accessToken: string;
+
+    @doc("The expiration date of the refresh token.")
+    expirationTime: integer;
+
+    @doc("The new refresh token.")
+    refreshToken: string;
+  }
+
+  @route("/auth/login/oauth/{provider}")
+  @get
+  op loginGoogle(
+    @doc("The OAuth2 provider to use for login.")
+    @path
+    provider: OAuthProviders,
+
+    @doc("The callback URL of the OAuth2 login. [See details](https://clustron.atlassian.net/wiki/spaces/cd/pages/18219016/Backend+OAuth+JWT+Manual)")
+    @query
+    c: string,
+
+    @doc("The redirect URL for login callback.")
+    @query
+    r?: string,
+  ): {
+    @statusCode statusCode: 302;
+  } | {
+    @statusCode statusCode: 404;
+  };
+
+  @route("/auth/refresh/{refreshToken}")
+  @get
+  op refreshToken(
+    @doc("The refresh token to use for refreshing the access token.")
+    @path
+    refreshToken: string,
+  ): {
+    @statusCode statusCode: 200;
+    @body refreshToken: RefreshToken;
+  } | {
+    @statusCode statusCode: 404;
+  };
+}

--- a/service/auth.tsp
+++ b/service/auth.tsp
@@ -26,7 +26,7 @@ namespace CoreSystem.Auth {
     @path
     provider: OAuthProviders,
 
-    @doc("The callback URL of the OAuth2 login. [See details](https://clustron.atlassian.net/wiki/spaces/cd/pages/18219016/Backend+OAuth+JWT+Manual)")
+    @doc("The callback URL of the OAuth2 login. [See details](https://clustron.atlassian.net/wiki/spaces/CS/pages/41320449/Authentication+Process)")
     @query
     c: string,
 

--- a/service/auth.tsp
+++ b/service/auth.tsp
@@ -40,7 +40,7 @@ namespace Clustron.Auth {
   };
 
   @route("/auth/refresh/{refreshToken}")
-  @get
+  @post
   op refreshToken(
     @doc("The refresh token to use for refreshing the access token.")
     @path

--- a/service/healthz.tsp
+++ b/service/healthz.tsp
@@ -4,12 +4,11 @@ using Http;
 
 @tag("Healthz")
 namespace CoreSystem.Healthz {
-    
-    @route("/healthz")
-    @get
-    op checkHealthz(): {
-        @statusCode statusCode: 200
-    } | {
-        @statusCode statusCode: 404
-    };
+  @route("/healthz")
+  @get
+  op checkHealthz(): {
+    @statusCode statusCode: 200;
+  } | {
+    @statusCode statusCode: 404;
+  };
 }


### PR DESCRIPTION
## Type of changes
- Docs

## Purpose
Implement Google OAuth login flow with redirect support within the below endpoint:

- `GET /api/auth/login/oauth/{provider}`
- `POST /api/auth/refresh/{refreshToken}`

Detailed design see: [Authentication Process](https://clustron.atlassian.net/wiki/x/AYB2Ag)