### PR TITLE
[CORE-1] Add user me endpoint and Unauthorized error

### DIFF
--- a/main.tsp
+++ b/main.tsp
@@ -2,6 +2,7 @@ import "@typespec/http";
 import "@typespec/versioning";
 import "./service/healthz.tsp";
 import "./service/auth.tsp";
+import "./service/user.tsp";
 
 using Http;
 using Versioning;
@@ -14,4 +15,36 @@ namespace CoreSystem;
 
 enum Versions {
   v1: "1.0.0",
+}
+
+@error
+@doc("Problem represents a problem detail as defined in RFC 7807")
+model ProblemDetail {
+  @doc("The problem's title.")
+  title: string;
+
+  @doc("The problem's status code.")
+  status: integer;
+
+  @doc("Type indicates the URI that identifies the problem type, we use an MDN URI here.")
+  type: string;
+
+  @doc("The problem's detail.")
+  detail: string;
+}
+
+@error
+model Unauthorized {
+  title: "Unauthorized";
+  status: 401;
+  type: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401";
+  detail: string;
+}
+
+@error
+model NotFound {
+  title: "Not Found";
+  status: 404;
+  type: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404";
+  detail: string;
 }

--- a/main.tsp
+++ b/main.tsp
@@ -17,6 +17,9 @@ enum Versions {
   v1: "1.0.0",
 }
 
+@format("uuid")
+scalar uuid extends string;
+
 @error
 @doc("Problem represents a problem detail as defined in RFC 7807")
 model ProblemDetail {

--- a/service/user.tsp
+++ b/service/user.tsp
@@ -1,0 +1,37 @@
+import "@typespec/http";
+
+using Http;
+
+@tag("User")
+namespace CoreSystem.User {
+  enum Role {
+    user: "user",
+  }
+
+  model User {
+    @doc("The user's username, unique across the system.")
+    username: string;
+
+    @doc("The user's name, usually the first and last name.")
+    name: string;
+
+    @doc("Avatar URL of the user.")
+    avatarUrl: string;
+
+    @doc("Global role of the user.")
+    roles: Role[];
+  }
+
+  @get
+  @route("/user/me")
+  @doc("Get the current user's information.")
+  op getMe(): {
+    @statusCode statusCode: 200;
+    @body user: User;
+  } | {
+    @statusCode
+    statusCode: 401;
+
+    @body error: Unauthorized;
+  };
+}

--- a/service/user.tsp
+++ b/service/user.tsp
@@ -9,7 +9,10 @@ namespace CoreSystem.User {
   }
 
   model User {
-    @doc("The user's username, unique across the system.")
+    @doc("The user's unique identifier.")
+    id: uuid;
+
+    @doc("The user's username, can change, but must be unique across the system.")
     username: string;
 
     @doc("The user's name, usually the first and last name.")

--- a/service/user.tsp
+++ b/service/user.tsp
@@ -26,7 +26,7 @@ namespace CoreSystem.User {
   }
 
   @get
-  @route("/user/me")
+  @route("/users/me")
   @doc("Get the current user's information.")
   op getMe(): {
     @statusCode statusCode: 200;


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Add `/user/me` endpoint for authenticated user info  
  - Enables frontend to determine login status via API  
  - Required due to use of HttpOnly cookies for access/refresh tokens
- Define `User` model  
  - `id`: user's unique identifier (UUID)  
  - `username`: Can change, but must be unique across the system  
  - `name`: display name (usually full name)  
  - `avatarUrl`: currently Google-provided
  - `roles`: currently fixed as `[user]`  
- Add reusable error models (RFC 7807 style)  
  - `ProblemDetail`: generic error response schema  
  - `Unauthorized`: 401-specific schema  
  - `NotFound`: 404-specific schema  
- Known issue  
  - `avatarUrl` is not stable; user profile system not implemented yet
