### PR TITLE
[CORE-83] Add preview field to API Spec

### DIFF
--- a/service/forms.tsp
+++ b/service/forms.tsp
@@ -12,6 +12,9 @@ namespace CoreSystem.Forms {
 
     @doc("The description of the form.")
     description: string;
+
+    @doc("(Optional) Preview text for the form. If not provided, fallback to first 25 characters of description.")
+    previewMessage?: string;
   }
 
   @doc("The structure of a form.")
@@ -24,6 +27,9 @@ namespace CoreSystem.Forms {
 
     @doc("The description written in the form to show user info.")
     description: string;
+
+    @doc("(Optional) Preview text for the form. If not provided, fallback to first 25 characters of description.")
+    previewMessage?: string;
 
     @doc("The status of this form.")
     status: FormStatus;

--- a/service/inbox.tsp
+++ b/service/inbox.tsp
@@ -64,6 +64,9 @@ namespace CoreSystem.Inbox {
     @doc("The type of the content.")
     type: contentType;
 
+    @doc("(Optional) Preview text. For forms: uses form.previewMessage if set, otherwise first 25 chars of form.description. For text: uses provided preview message if set, otherwise first 25 chars of content.")
+    previewMessage: string;
+
     @doc("(Optional) The identifier of the content referenced by the contentType.")
     contentId?: uuid;
 

--- a/service/inbox.tsp
+++ b/service/inbox.tsp
@@ -64,7 +64,7 @@ namespace CoreSystem.Inbox {
     @doc("The type of the content.")
     type: contentType;
 
-    @doc("(Optional) Preview text. For forms: uses form.previewMessage if set, otherwise first 25 chars of form.description. For text: uses provided preview message if set, otherwise first 25 chars of content.")
+    @doc("Preview text. For forms: uses form.previewMessage if set, otherwise first 25 chars of form.description. For text: uses provided preview message if set, otherwise first 25 chars of content.")
     previewMessage: string;
 
     @doc("(Optional) The identifier of the content referenced by the contentType.")


### PR DESCRIPTION
## Type of changes
- Feature
## Purpose
- Add preview field to form to display in inbox message

## Additional Information
The preview field is an optional field in form. If it is not provided, the value will be returned as null, and the system will fall back to the first 25 characters of the description.

