### PR TITLE
Add logout API endpoint

### DIFF
--- a/service/auth.tsp
+++ b/service/auth.tsp
@@ -53,4 +53,12 @@ namespace CoreSystem.Auth {
   } | {
     @statusCode statusCode: 404;
   };
+
+  @route("/auth/logout")
+  @post
+  op logout(): {
+    @statusCode statusCode: 200;
+  } | {
+    @statusCode statusCode: 401;
+  };
 }


### PR DESCRIPTION
## Type of changes

- Feature

## Purpose

- Add logout API endpoint to the Auth service
- Provide a standardized way for users to logout from the system

This PR adds a new `POST /api/auth/logout` endpoint that allows authenticated users to logout. The endpoint returns:
- `200` on successful logout
- `401` if the user is not authenticated

## Additional Information

The logout endpoint follows the same pattern as other auth endpoints in `service/auth.tsp`. It has been compiled and verified to generate correct OpenAPI specification at `/api/auth/logout`.