### PR TITLE
[CORE-251] Add Markdown support

### DIFF
--- a/src/form/answer/models.tsp
+++ b/src/form/answer/models.tsp
@@ -166,7 +166,7 @@ namespace CoreSystem.Responses {
 			required: true,
 			type: CoreSystem.Forms.QuestionTypes.shortText,
 			title: "What's your name?",
-			description: "Please enter your full name",
+			description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Please enter your full name" }] }] },
 			createdAt: utcDateTime.fromISO("2025-01-20T10:00:00Z"),
 			updatedAt: utcDateTime.fromISO("2025-02-01T15:30:00Z"),
 		},

--- a/src/form/models.tsp
+++ b/src/form/models.tsp
@@ -19,8 +19,8 @@ namespace CoreSystem.Forms {
 		@doc("The title of the form.")
 		title: string;
 
-		@doc("The description of the form.")
-		description?: string;
+		@doc("The form description in Markdown, edited and stored by the admin interface.")
+		description?: CoreSystem.MarkdownContent;
 
 		@doc("(Optional) Preview text for the form. If not provided, fallback to first 25 characters of description.")
 		previewMessage?: string;
@@ -51,7 +51,8 @@ namespace CoreSystem.Forms {
 	@example(#{
 		id: "9a843aa0-8451-4e3b-b6a0-8c0e994e9040",
 		title: "SDC 2025 Recruitment Form",
-		description: "Join us for an exciting journey in software development!",
+		description: "Join us for an exciting journey in **software development**!",
+		descriptionHtml: "<p>Join us for an exciting journey in <strong>software development</strong>!</p>",
 		previewMessage: "Join us for an exciting journey",
 		status: FormStatus.published,
 		unitId: "d26e9c90-4747-496b-9953-7e7c4f97643f",
@@ -73,8 +74,11 @@ namespace CoreSystem.Forms {
 		@doc("The title of the form.")
 		title: string;
 
-		@doc("The description written in the form to show user info.")
-		description: string;
+		@doc("The form description in Markdown, for admin editing.")
+		description: CoreSystem.MarkdownContent;
+
+		@doc("The form description rendered as HTML for frontend form display and preview.")
+		descriptionHtml?: CoreSystem.HtmlContent;
 
 		@doc("Preview text. If not provided, fallback to first 25 characters of description.")
 		previewMessage: string;
@@ -137,7 +141,8 @@ namespace CoreSystem.Forms {
 		id: "b23f2668-c2dc-4213-88fe-eceedff46398",
 		formId: "9a843aa0-8451-4e3b-b6a0-8c0e994e9040",
 		title: "Personal Information",
-		description: "Please provide your basic information",
+		description: "Please provide your **basic information**",
+		descriptionHtml: "<p>Please provide your <strong>basic information</strong></p>",
 		questions: #[],
 	})
 	model Section {
@@ -150,21 +155,24 @@ namespace CoreSystem.Forms {
 		@doc("Section title (e.g., 'Group Info').")
 		title: string;
 
-		@doc("Section description.")
-		description?: string;
+		@doc("The section description in Markdown, for admin editing.")
+		description?: CoreSystem.MarkdownContent;
+
+		@doc("The section description rendered as HTML for frontend form display and preview.")
+		descriptionHtml?: CoreSystem.HtmlContent;
 
 		@doc("The questions of the section.")
 		questions: QuestionResponse[];
 	}
 
 	@doc("The request body for updating a section.")
-	@example(#{ title: "Personal Information", description: "Please provide your basic information" })
+	@example(#{ title: "Personal Information", description: "Please provide your **basic information**" })
 	model SectionRequest {
 		@doc("Section title (e.g., 'Group Info').")
 		title: string;
 
-		@doc("Section description.")
-		description?: string;
+		@doc("The section description in Markdown, edited and stored by the admin interface.")
+		description?: CoreSystem.MarkdownContent;
 	}
 
 	@doc("The current progress of a section")

--- a/src/form/models.tsp
+++ b/src/form/models.tsp
@@ -14,13 +14,13 @@ namespace CoreSystem.Forms {
 	}
 
 	@doc("The request body for creating/updating a form.")
-	@example(#{ title: "Enter SDC Form", description: "If you want to join us, just fill in this form!", messageAfterSubmission: "Thank you for your submission!", visibility: FormVisibility.public })
+	@example(#{ title: "Enter SDC Form", description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "If you want to join us, just fill in this form!" }] }] }, messageAfterSubmission: "Thank you for your submission!", visibility: FormVisibility.public })
 	model FormRequest {
 		@doc("The title of the form.")
 		title: string;
 
-		@doc("The form description in Markdown, edited and stored by the admin interface.")
-		description?: CoreSystem.MarkdownContent;
+		@doc("The form description as ProseMirror JSON, edited in Tiptap and sent by the admin interface.")
+		description?: CoreSystem.ProseMirrorDocument;
 
 		@doc("(Optional) Preview text for the form. If not provided, fallback to first 25 characters of description.")
 		previewMessage?: string;
@@ -51,7 +51,7 @@ namespace CoreSystem.Forms {
 	@example(#{
 		id: "9a843aa0-8451-4e3b-b6a0-8c0e994e9040",
 		title: "SDC 2025 Recruitment Form",
-		description: "Join us for an exciting journey in **software development**!",
+		description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Join us for an exciting journey in " }, #{ type: "text", marks: #[#{ type: "bold" }], text: "software development" }, #{ type: "text", text: "!" }] }] },
 		descriptionHtml: "<p>Join us for an exciting journey in <strong>software development</strong>!</p>",
 		previewMessage: "Join us for an exciting journey",
 		status: FormStatus.published,
@@ -74,8 +74,8 @@ namespace CoreSystem.Forms {
 		@doc("The title of the form.")
 		title: string;
 
-		@doc("The form description in Markdown, for admin editing.")
-		description: CoreSystem.MarkdownContent;
+		@doc("The form description as ProseMirror JSON, for admin editing in Tiptap.")
+		description: CoreSystem.ProseMirrorDocument;
 
 		@doc("The form description rendered as HTML for frontend form display and preview.")
 		descriptionHtml?: CoreSystem.HtmlContent;
@@ -141,7 +141,7 @@ namespace CoreSystem.Forms {
 		id: "b23f2668-c2dc-4213-88fe-eceedff46398",
 		formId: "9a843aa0-8451-4e3b-b6a0-8c0e994e9040",
 		title: "Personal Information",
-		description: "Please provide your **basic information**",
+		description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Please provide your " }, #{ type: "text", marks: #[#{ type: "bold" }], text: "basic information" }] }] },
 		descriptionHtml: "<p>Please provide your <strong>basic information</strong></p>",
 		questions: #[],
 	})
@@ -155,8 +155,8 @@ namespace CoreSystem.Forms {
 		@doc("Section title (e.g., 'Group Info').")
 		title: string;
 
-		@doc("The section description in Markdown, for admin editing.")
-		description?: CoreSystem.MarkdownContent;
+		@doc("The section description as ProseMirror JSON, for admin editing in Tiptap.")
+		description?: CoreSystem.ProseMirrorDocument;
 
 		@doc("The section description rendered as HTML for frontend form display and preview.")
 		descriptionHtml?: CoreSystem.HtmlContent;
@@ -166,13 +166,13 @@ namespace CoreSystem.Forms {
 	}
 
 	@doc("The request body for updating a section.")
-	@example(#{ title: "Personal Information", description: "Please provide your **basic information**" })
+	@example(#{ title: "Personal Information", description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Please provide your " }, #{ type: "text", marks: #[#{ type: "bold" }], text: "basic information" }] }] } })
 	model SectionRequest {
 		@doc("Section title (e.g., 'Group Info').")
 		title: string;
 
-		@doc("The section description in Markdown, edited and stored by the admin interface.")
-		description?: CoreSystem.MarkdownContent;
+		@doc("The section description as ProseMirror JSON, edited in Tiptap and sent by the admin interface.")
+		description?: CoreSystem.ProseMirrorDocument;
 	}
 
 	@doc("The current progress of a section")
@@ -209,7 +209,7 @@ namespace CoreSystem.Forms {
 				id: "b23f2668-c2dc-4213-88fe-eceedff46398",
 				formId: "9a843aa0-8451-4e3b-b6a0-8c0e994e9040",
 				title: "Personal Information",
-				description: "Please provide your basic information",
+				description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Please provide your basic information" }] }] },
 				questions: #[
 					#{
 						id: "ee894524-4bd8-4a64-8fd2-a53b39ca94cd",
@@ -217,7 +217,7 @@ namespace CoreSystem.Forms {
 						required: true,
 						type: QuestionTypes.shortText,
 						title: "Full Name",
-						description: "Please enter your full name (in English)",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Please enter your full name (in English)" }] }] },
 						createdAt: utcDateTime.fromISO("2025-01-20T10:00:00Z"),
 						updatedAt: utcDateTime.fromISO("2025-02-01T15:30:00Z"),
 					},
@@ -227,7 +227,7 @@ namespace CoreSystem.Forms {
 						required: true,
 						type: QuestionTypes.shortText,
 						title: "Student ID",
-						description: "Enter your student ID number",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Enter your student ID number" }] }] },
 						createdAt: utcDateTime.fromISO("2025-01-20T10:00:00Z"),
 						updatedAt: utcDateTime.fromISO("2025-02-01T15:30:00Z"),
 					},
@@ -237,7 +237,7 @@ namespace CoreSystem.Forms {
 						required: true,
 						type: QuestionTypes.shortText,
 						title: "Email Address",
-						description: "Please provide your email address",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Please provide your email address" }] }] },
 						createdAt: utcDateTime.fromISO("2025-01-20T10:00:00Z"),
 						updatedAt: utcDateTime.fromISO("2025-02-01T15:30:00Z"),
 					},
@@ -247,7 +247,7 @@ namespace CoreSystem.Forms {
 						required: true,
 						type: QuestionTypes.shortText,
 						title: "Phone Number",
-						description: "Your contact phone number",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Your contact phone number" }] }] },
 						createdAt: utcDateTime.fromISO("2025-01-20T10:00:00Z"),
 						updatedAt: utcDateTime.fromISO("2025-02-01T15:30:00Z"),
 					},
@@ -257,7 +257,7 @@ namespace CoreSystem.Forms {
 						required: true,
 						type: QuestionTypes.date,
 						title: "Date of Birth",
-						description: "Select your date of birth",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Select your date of birth" }] }] },
 						date: #{ hasYear: true, hasMonth: true, hasDay: true, minDate: utcDateTime.fromISO("1990-01-01T00:00:00Z"), maxDate: utcDateTime.fromISO("2010-12-31T23:59:59Z") },
 						createdAt: utcDateTime.fromISO("2025-01-20T10:00:00Z"),
 						updatedAt: utcDateTime.fromISO("2025-02-01T15:30:00Z"),
@@ -268,7 +268,7 @@ namespace CoreSystem.Forms {
 						required: true,
 						type: QuestionTypes.longText,
 						title: "Self Introduction",
-						description: "Tell us about yourself (200-500 words)",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Tell us about yourself (200-500 words)" }] }] },
 						createdAt: utcDateTime.fromISO("2025-01-20T10:00:00Z"),
 						updatedAt: utcDateTime.fromISO("2025-02-01T15:30:00Z"),
 					}
@@ -278,7 +278,7 @@ namespace CoreSystem.Forms {
 				id: "c34d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f",
 				formId: "9a843aa0-8451-4e3b-b6a0-8c0e994e9040",
 				title: "Academic & Experience",
-				description: "Tell us about your academic background and experience",
+				description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Tell us about your academic background and experience" }] }] },
 				questions: #[
 					#{
 						id: "a7b8c9d0-1e2f-3a4b-5c6d-7e8f9a0b1c2d",
@@ -286,7 +286,7 @@ namespace CoreSystem.Forms {
 						required: true,
 						type: QuestionTypes.dropdown,
 						title: "Current Education Level",
-						description: "Select your current education level",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Select your current education level" }] }] },
 						choices: #[
 							#{ id: "ch1-1", name: "Freshman" },
 							#{ id: "ch1-2", name: "Sophomore" },
@@ -303,7 +303,7 @@ namespace CoreSystem.Forms {
 						required: true,
 						type: QuestionTypes.singleChoice,
 						title: "Department/Major",
-						description: "Select your department or major",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Select your department or major" }] }] },
 						choices: #[
 							#{ id: "ch2-1", name: "Computer Science" },
 							#{ id: "ch2-2", name: "Information Management" },
@@ -320,7 +320,7 @@ namespace CoreSystem.Forms {
 						required: true,
 						type: QuestionTypes.date,
 						title: "Expected Graduation Date",
-						description: "When do you expect to graduate?",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "When do you expect to graduate?" }] }] },
 						date: #{ hasYear: true, hasMonth: true, hasDay: false, minDate: utcDateTime.fromISO("2025-01-01T00:00:00Z"), maxDate: utcDateTime.fromISO("2030-12-31T23:59:59Z") },
 						createdAt: utcDateTime.fromISO("2025-01-20T10:00:00Z"),
 						updatedAt: utcDateTime.fromISO("2025-02-01T15:30:00Z"),
@@ -331,7 +331,7 @@ namespace CoreSystem.Forms {
 						required: false,
 						type: QuestionTypes.multipleChoice,
 						title: "Previous Experience",
-						description: "Select all that apply",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Select all that apply" }] }] },
 						choices: #[
 							#{ id: "ch3-1", name: "Participated in hackathons" },
 							#{ id: "ch3-2", name: "Open source contributor" },
@@ -349,7 +349,7 @@ namespace CoreSystem.Forms {
 				id: "d45e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a",
 				formId: "9a843aa0-8451-4e3b-b6a0-8c0e994e9040",
 				title: "Technical Skills",
-				description: "Tell us about your technical expertise",
+				description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Tell us about your technical expertise" }] }] },
 				questions: #[
 					#{
 						id: "e1f2a3b4-5c6d-7e8f-9a0b-1c2d3e4f5a6b",
@@ -357,7 +357,7 @@ namespace CoreSystem.Forms {
 						required: true,
 						type: QuestionTypes.detailedMultipleChoice,
 						title: "Programming Languages",
-						description: "Select all programming languages you are familiar with",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Select all programming languages you are familiar with" }] }] },
 						choices: #[
 							#{ id: "ch4-1", name: "TypeScript/JavaScript", description: "Modern web development" },
 							#{ id: "ch4-2", name: "Python", description: "General purpose and data science" },
@@ -375,7 +375,7 @@ namespace CoreSystem.Forms {
 						required: true,
 						type: QuestionTypes.linearScale,
 						title: "Backend Development Experience",
-						description: "Rate your backend development experience level",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Rate your backend development experience level" }] }] },
 						scale: #{ minVal: 0, maxVal: 10, minValueLabel: "Beginner", maxValueLabel: "Expert" },
 						createdAt: utcDateTime.fromISO("2025-01-20T10:00:00Z"),
 						updatedAt: utcDateTime.fromISO("2025-02-01T15:30:00Z"),
@@ -386,7 +386,7 @@ namespace CoreSystem.Forms {
 						required: true,
 						type: QuestionTypes.linearScale,
 						title: "Frontend Development Experience",
-						description: "Rate your frontend development experience level",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Rate your frontend development experience level" }] }] },
 						scale: #{ minVal: 0, maxVal: 10, minValueLabel: "Beginner", maxValueLabel: "Expert" },
 						createdAt: utcDateTime.fromISO("2025-01-20T10:00:00Z"),
 						updatedAt: utcDateTime.fromISO("2025-02-01T15:30:00Z"),
@@ -397,7 +397,7 @@ namespace CoreSystem.Forms {
 						required: true,
 						type: QuestionTypes.rating,
 						title: "DevOps & Infrastructure",
-						description: "Rate your familiarity with DevOps practices and infrastructure",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Rate your familiarity with DevOps practices and infrastructure" }] }] },
 						scale: #{ icon: "star", minVal: 1, maxVal: 5, minValueLabel: "Novice", maxValueLabel: "Proficient" },
 						createdAt: utcDateTime.fromISO("2025-01-20T10:00:00Z"),
 						updatedAt: utcDateTime.fromISO("2025-02-01T15:30:00Z"),
@@ -408,7 +408,7 @@ namespace CoreSystem.Forms {
 						required: false,
 						type: QuestionTypes.multipleChoice,
 						title: "Technologies You've Worked With",
-						description: "Select all technologies you have experience with",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Select all technologies you have experience with" }] }] },
 						choices: #[
 							#{ id: "ch5-1", name: "Docker" },
 							#{ id: "ch5-2", name: "Kubernetes" },
@@ -430,7 +430,7 @@ namespace CoreSystem.Forms {
 				id: "e56f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b",
 				formId: "9a843aa0-8451-4e3b-b6a0-8c0e994e9040",
 				title: "Team Preferences",
-				description: "Help us understand your team preferences",
+				description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Help us understand your team preferences" }] }] },
 				questions: #[
 					#{
 						id: "d6e7f8a9-0b1c-2d3e-4f5a-6b7c8d9e0f1a",
@@ -438,7 +438,7 @@ namespace CoreSystem.Forms {
 						required: true,
 						type: QuestionTypes.ranking,
 						title: "Team Preferences",
-						description: "Rank the following teams in order of your preference (1 = most preferred)",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Rank the following teams in order of your preference (1 = most preferred)" }] }] },
 						choices: #[
 							#{ id: "team-1", name: "Core System Team", description: "Backend API & infrastructure development" },
 							#{ id: "team-2", name: "Clustron Team", description: "Cluster management and distributed systems" },
@@ -454,7 +454,7 @@ namespace CoreSystem.Forms {
 						required: true,
 						type: QuestionTypes.singleChoice,
 						title: "Role Preference",
-						description: "Which role are you most interested in?",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Which role are you most interested in?" }] }] },
 						choices: #[
 							#{ id: "role-1", name: "Backend Developer" },
 							#{ id: "role-2", name: "Frontend Developer" },
@@ -472,7 +472,7 @@ namespace CoreSystem.Forms {
 						required: true,
 						type: QuestionTypes.longText,
 						title: "Why SDC?",
-						description: "Why do you want to join SDC? What are your expectations?",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Why do you want to join SDC? What are your expectations?" }] }] },
 						createdAt: utcDateTime.fromISO("2025-01-20T10:00:00Z"),
 						updatedAt: utcDateTime.fromISO("2025-02-01T15:30:00Z"),
 					},
@@ -482,7 +482,7 @@ namespace CoreSystem.Forms {
 						required: true,
 						type: QuestionTypes.rating,
 						title: "Team Collaboration",
-						description: "How comfortable are you working in a team environment?",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "How comfortable are you working in a team environment?" }] }] },
 						scale: #{ icon: "heart", minVal: 1, maxVal: 5, minValueLabel: "Prefer solo", maxValueLabel: "Love teamwork" },
 						createdAt: utcDateTime.fromISO("2025-01-20T10:00:00Z"),
 						updatedAt: utcDateTime.fromISO("2025-02-01T15:30:00Z"),
@@ -493,7 +493,7 @@ namespace CoreSystem.Forms {
 				id: "f67a8b9c-0d1e-2f3a-4b5c-6d7e8f9a0b1c",
 				formId: "9a843aa0-8451-4e3b-b6a0-8c0e994e9040",
 				title: "Availability & Additional Information",
-				description: "Final section - availability and additional materials",
+				description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Final section - availability and additional materials" }] }] },
 				questions: #[
 					#{
 						id: "b0c1d2e3-4f5a-6b7c-8d9e-0f1a2b3c4d5e",
@@ -501,7 +501,7 @@ namespace CoreSystem.Forms {
 						required: true,
 						type: QuestionTypes.multipleChoice,
 						title: "Weekly Availability",
-						description: "Which days are you available each week? (Select all that apply)",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Which days are you available each week? (Select all that apply)" }] }] },
 						choices: #[
 							#{ id: "day-1", name: "Monday" },
 							#{ id: "day-2", name: "Tuesday" },
@@ -520,7 +520,7 @@ namespace CoreSystem.Forms {
 						required: true,
 						type: QuestionTypes.linearScale,
 						title: "Time Commitment",
-						description: "How many hours per week can you commit to SDC activities?",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "How many hours per week can you commit to SDC activities?" }] }] },
 						scale: #{ minVal: 0, maxVal: 10, minValueLabel: "0-5 hours", maxValueLabel: "20+ hours" },
 						createdAt: utcDateTime.fromISO("2025-01-20T10:00:00Z"),
 						updatedAt: utcDateTime.fromISO("2025-02-01T15:30:00Z"),
@@ -531,7 +531,7 @@ namespace CoreSystem.Forms {
 						required: true,
 						type: QuestionTypes.uploadFile,
 						title: "Resume/CV",
-						description: "Please upload your resume or CV",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Please upload your resume or CV" }] }] },
 						uploadFile: #{ allowedFileTypes: #[allowedFileTypes.pdf, allowedFileTypes.doc, allowedFileTypes.docx], maxFileAmount: 1, maxFileSizeLimit: 5242880 },
 						createdAt: utcDateTime.fromISO("2025-01-20T10:00:00Z"),
 						updatedAt: utcDateTime.fromISO("2025-02-01T15:30:00Z"),
@@ -542,7 +542,7 @@ namespace CoreSystem.Forms {
 						required: false,
 						type: QuestionTypes.uploadFile,
 						title: "Portfolio/Projects",
-						description: "Upload any relevant portfolio materials or project documentation (optional)",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Upload any relevant portfolio materials or project documentation (optional)" }] }] },
 						uploadFile: #{ allowedFileTypes: #[allowedFileTypes.pdf, allowedFileTypes.zip], maxFileAmount: 3, maxFileSizeLimit: 10485760 },
 						createdAt: utcDateTime.fromISO("2025-01-20T10:00:00Z"),
 						updatedAt: utcDateTime.fromISO("2025-02-01T15:30:00Z"),
@@ -553,7 +553,7 @@ namespace CoreSystem.Forms {
 						required: false,
 						type: QuestionTypes.hyperlink,
 						title: "GitHub Profile",
-						description: "Link to your GitHub profile (if available)",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Link to your GitHub profile (if available)" }] }] },
 						createdAt: utcDateTime.fromISO("2025-01-20T10:00:00Z"),
 						updatedAt: utcDateTime.fromISO("2025-02-01T15:30:00Z"),
 					},
@@ -563,7 +563,7 @@ namespace CoreSystem.Forms {
 						required: false,
 						type: QuestionTypes.hyperlink,
 						title: "LinkedIn Profile",
-						description: "Link to your LinkedIn profile (optional)",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Link to your LinkedIn profile (optional)" }] }] },
 						createdAt: utcDateTime.fromISO("2025-01-20T10:00:00Z"),
 						updatedAt: utcDateTime.fromISO("2025-02-01T15:30:00Z"),
 					},
@@ -573,7 +573,7 @@ namespace CoreSystem.Forms {
 						required: false,
 						type: QuestionTypes.hyperlink,
 						title: "Personal Website/Blog",
-						description: "Link to your personal website or blog (if any)",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Link to your personal website or blog (if any)" }] }] },
 						createdAt: utcDateTime.fromISO("2025-01-20T10:00:00Z"),
 						updatedAt: utcDateTime.fromISO("2025-02-01T15:30:00Z"),
 					},
@@ -583,7 +583,7 @@ namespace CoreSystem.Forms {
 						required: false,
 						type: QuestionTypes.longText,
 						title: "Anything Else?",
-						description: "Is there anything else you'd like us to know?",
+						description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Is there anything else you'd like us to know?" }] }] },
 						createdAt: utcDateTime.fromISO("2025-01-20T10:00:00Z"),
 						updatedAt: utcDateTime.fromISO("2025-02-01T15:30:00Z"),
 					}

--- a/src/form/operations.tsp
+++ b/src/form/operations.tsp
@@ -9,13 +9,13 @@ namespace CoreSystem.Forms {
 	op listForms(): Form[];
 
 	@summary("Get Form")
-	@doc("Get a specific form by its unique identifier. Description fields are returned as Markdown for admin editing, with rendered HTML available in `descriptionHtml` when applicable.")
+	@doc("Get a specific form by its unique identifier. Description fields are returned as ProseMirror JSON for admin editing, with rendered HTML available in `descriptionHtml` for frontend display.")
 	@route("/forms/{formId}")
 	@get
 	op getFormById(@path formId: uuid): Form;
 
 	@summary("Update Form")
-	@doc("Update an existing form by its unique identifier. Description fields in the request body should be sent as Markdown.")
+	@doc("Update an existing form by its unique identifier. Description fields in the request body should be sent as ProseMirror JSON from the Tiptap editor.")
 	@route("/forms/{formId}")
 	@patch(#{ implicitOptionality: true })
 	op updateForm(@path formId: uuid, @body updateFormRequest: FormRequest): Form;
@@ -64,13 +64,13 @@ namespace CoreSystem.Forms {
 
 	// === Section Operations ===
 	@summary("List Sections")
-	@doc("List all the questions of the sections in the form. Descriptions are returned in Markdown for admin editing, with rendered HTML available in `descriptionHtml` for frontend form display and preview.")
+	@doc("List all the questions of the sections in the form. Descriptions are returned as ProseMirror JSON for admin editing, with rendered HTML available in `descriptionHtml` for frontend form display and preview.")
 	@route("/forms/{formId}/sections")
 	@get
 	op listSections(@path formId: uuid): ListSectionsResponse[];
 
 	@summary("Update Section")
-	@doc("Update an existing section by its unique identifier. Description fields in the request body should be sent as Markdown.")
+	@doc("Update an existing section by its unique identifier. Description fields in the request body should be sent as ProseMirror JSON from the Tiptap editor.")
 	@route("/forms/{formId}/sections/{sectionId}")
 	@patch(#{ implicitOptionality: true })
 	op updateSection(@path formId: uuid, @path sectionId: uuid, @body updateSectionRequest: SectionRequest): Section;

--- a/src/form/operations.tsp
+++ b/src/form/operations.tsp
@@ -9,13 +9,13 @@ namespace CoreSystem.Forms {
 	op listForms(): Form[];
 
 	@summary("Get Form")
-	@doc("Get a specific form by its unique identifier.")
+	@doc("Get a specific form by its unique identifier. Description fields are returned as Markdown for admin editing, with rendered HTML available in `descriptionHtml` when applicable.")
 	@route("/forms/{formId}")
 	@get
 	op getFormById(@path formId: uuid): Form;
 
 	@summary("Update Form")
-	@doc("Update an existing form by its unique identifier.")
+	@doc("Update an existing form by its unique identifier. Description fields in the request body should be sent as Markdown.")
 	@route("/forms/{formId}")
 	@patch(#{ implicitOptionality: true })
 	op updateForm(@path formId: uuid, @body updateFormRequest: FormRequest): Form;
@@ -64,13 +64,13 @@ namespace CoreSystem.Forms {
 
 	// === Section Operations ===
 	@summary("List Sections")
-	@doc("List all the questions of the sections in the form.")
+	@doc("List all the questions of the sections in the form. Descriptions are returned in Markdown for admin editing, with rendered HTML available in `descriptionHtml` for frontend form display and preview.")
 	@route("/forms/{formId}/sections")
 	@get
 	op listSections(@path formId: uuid): ListSectionsResponse[];
 
 	@summary("Update Section")
-	@doc("Update an existing section by its unique identifier.")
+	@doc("Update an existing section by its unique identifier. Description fields in the request body should be sent as Markdown.")
 	@route("/forms/{formId}/sections/{sectionId}")
 	@patch(#{ implicitOptionality: true })
 	op updateSection(@path formId: uuid, @path sectionId: uuid, @body updateSectionRequest: SectionRequest): Section;

--- a/src/form/question/models.tsp
+++ b/src/form/question/models.tsp
@@ -198,7 +198,7 @@ namespace CoreSystem.Forms {
 		required: true,
 		type: QuestionTypes.shortText,
 		title: "What's your name?",
-		description: "Please enter your **full name**",
+		description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Please enter your " }, #{ type: "text", marks: #[#{ type: "bold" }], text: "full name" }] }] },
 		descriptionHtml: "<p>Please enter your <strong>full name</strong></p>",
 		createdAt: utcDateTime.fromISO("2025-01-20T10:00:00Z"),
 		updatedAt: utcDateTime.fromISO("2025-02-01T15:30:00Z"),
@@ -219,8 +219,8 @@ namespace CoreSystem.Forms {
 		@doc("What is the question.")
 		title: string;
 
-		@doc("The question description in Markdown, for admin editing.")
-		description: CoreSystem.MarkdownContent;
+		@doc("The question description as ProseMirror JSON, for admin editing in Tiptap.")
+		description: CoreSystem.ProseMirrorDocument;
 
 		@doc("The question description rendered as HTML for frontend form display and preview.")
 		descriptionHtml?: CoreSystem.HtmlContent;
@@ -251,13 +251,13 @@ namespace CoreSystem.Forms {
 	}
 
 	@doc("The request body for creating/updating a question.")
-	@example(#{ required: true, type: QuestionTypes.shortText, title: "What's your name?", description: "Please enter your **name**", order: 1 })
-	@example(#{ required: true, type: QuestionTypes.longText, title: "Tell us about yourself", description: "Please share your **background** and experience", order: 2 })
+	@example(#{ required: true, type: QuestionTypes.shortText, title: "What's your name?", description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Please enter your " }, #{ type: "text", marks: #[#{ type: "bold" }], text: "name" }] }] }, order: 1 })
+	@example(#{ required: true, type: QuestionTypes.longText, title: "Tell us about yourself", description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Please share your " }, #{ type: "text", marks: #[#{ type: "bold" }], text: "background" }, #{ type: "text", text: " and experience" }] }] }, order: 2 })
 	@example(#{
 		required: true,
 		type: QuestionTypes.singleChoice,
 		title: "What's your preferred work location?",
-		description: "Choose one option",
+		description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Choose one option" }] }] },
 		order: 3,
 		choices: #[#{ name: "Remote" }, #{ name: "On-site" }, #{ name: "Hybrid" }, #{ name: "Other", isOther: true }],
 	})
@@ -265,7 +265,7 @@ namespace CoreSystem.Forms {
 		required: true,
 		type: QuestionTypes.multipleChoice,
 		title: "Which team you want to join???",
-		description: "Pick one of your favorite!!!",
+		description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Pick one of your favorite!!!" }] }] },
 		order: 4,
 		choices: #[#{ name: "Core System Team" }, #{ name: "Clustron Team" }, #{ name: "HPC Team" }],
 	})
@@ -273,7 +273,7 @@ namespace CoreSystem.Forms {
 		required: false,
 		type: QuestionTypes.dropdown,
 		title: "Select your experience level",
-		description: "Choose from the dropdown",
+		description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Choose from the dropdown" }] }] },
 		order: 5,
 		choices: #[#{ name: "Beginner" }, #{ name: "Intermediate" }, #{ name: "Advanced" }, #{ name: "Expert" }],
 	})
@@ -281,16 +281,16 @@ namespace CoreSystem.Forms {
 		required: true,
 		type: QuestionTypes.detailedMultipleChoice,
 		title: "Which technologies are you familiar with?",
-		description: "Select all that apply",
+		description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Select all that apply" }] }] },
 		order: 6,
 		choices: #[#{ name: "TypeScript", description: "Modern programming language" }, #{ name: "React", description: "Frontend library" }, #{ name: "Node.js", description: "Backend runtime" }],
 	})
-	@example(#{ required: true, type: QuestionTypes.date, title: "When will you graduate?", description: "Please select your graduation date", order: 7 })
+	@example(#{ required: true, type: QuestionTypes.date, title: "When will you graduate?", description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Please select your graduation date" }] }] }, order: 7 })
 	@example(#{
 		required: false,
 		type: QuestionTypes.uploadFile,
 		title: "Upload your resume",
-		description: "Please upload your resume in PDF format",
+		description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Please upload your resume in PDF format" }] }] },
 		order: 8,
 		uploadFile: #{ allowedFileTypes: #[allowedFileTypes.pdf, allowedFileTypes.doc, allowedFileTypes.docx], maxFileAmount: 1, maxFileSizeLimit: 1024000 },
 	})
@@ -298,16 +298,16 @@ namespace CoreSystem.Forms {
 		required: true,
 		type: QuestionTypes.linearScale,
 		title: "Rate your experience level (1-5)",
-		description: "How experienced are you?",
+		description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "How experienced are you?" }] }] },
 		order: 9,
 		scale: #{ minVal: 1, maxVal: 5, minValueLabel: "No experience", maxValueLabel: "Very experienced" },
 	})
-	@example(#{ required: true, type: QuestionTypes.rating, title: "How satisfied are you?", description: "Rate your satisfaction level", order: 10, scale: #{ icon: "star", minVal: 1, maxVal: 5 } })
+	@example(#{ required: true, type: QuestionTypes.rating, title: "How satisfied are you?", description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Rate your satisfaction level" }] }] }, order: 10, scale: #{ icon: "star", minVal: 1, maxVal: 5 } })
 	@example(#{
 		required: true,
 		type: QuestionTypes.ranking,
 		title: "Program Match",
-		description: "Sort the following programs based on your preference.",
+		description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Sort the following programs based on your preference." }] }] },
 		order: 11,
 		sourceId: "d290f1ee-6c54-4b01-90e6-d701748f0851",
 	})
@@ -315,7 +315,7 @@ namespace CoreSystem.Forms {
 		required: true,
 		type: QuestionTypes.oauthConnect,
 		title: "Connect your GitHub account",
-		description: "Link your GitHub account to verify your identity",
+		description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Link your GitHub account to verify your identity" }] }] },
 		order: 12,
 		oauthConnect: CoreSystem.Auth.OAuthProviders.github,
 	})
@@ -323,7 +323,7 @@ namespace CoreSystem.Forms {
 		required: true,
 		type: QuestionTypes.date,
 		title: "When will you graduate?",
-		description: "Please select your graduation date",
+		description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Please select your graduation date" }] }] },
 		order: 13,
 		date: #{ hasYear: true, hasMonth: true, hasDay: true },
 	})
@@ -331,7 +331,7 @@ namespace CoreSystem.Forms {
 		required: true,
 		type: QuestionTypes.date,
 		title: "Which year did you join?",
-		description: "Select year and month only",
+		description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "Select year and month only" }] }] },
 		order: 14,
 		date: #{ hasYear: true, hasMonth: true, hasDay: false },
 	})
@@ -345,8 +345,8 @@ namespace CoreSystem.Forms {
 		@doc("What is the question.")
 		title: string;
 
-		@doc("The question description in Markdown, edited and stored by the admin interface.")
-		description: CoreSystem.MarkdownContent;
+		@doc("The question description as ProseMirror JSON, edited in Tiptap and sent by the admin interface.")
+		description: CoreSystem.ProseMirrorDocument;
 
 		@doc("What is the number of this question in the form.")
 		order: int32;

--- a/src/form/question/models.tsp
+++ b/src/form/question/models.tsp
@@ -198,7 +198,8 @@ namespace CoreSystem.Forms {
 		required: true,
 		type: QuestionTypes.shortText,
 		title: "What's your name?",
-		description: "Please enter your full name",
+		description: "Please enter your **full name**",
+		descriptionHtml: "<p>Please enter your <strong>full name</strong></p>",
 		createdAt: utcDateTime.fromISO("2025-01-20T10:00:00Z"),
 		updatedAt: utcDateTime.fromISO("2025-02-01T15:30:00Z"),
 	})
@@ -218,8 +219,11 @@ namespace CoreSystem.Forms {
 		@doc("What is the question.")
 		title: string;
 
-		@doc("More details of this question.")
-		description: string;
+		@doc("The question description in Markdown, for admin editing.")
+		description: CoreSystem.MarkdownContent;
+
+		@doc("The question description rendered as HTML for frontend form display and preview.")
+		descriptionHtml?: CoreSystem.HtmlContent;
 
 		@doc("Available choice options for single_choice, multiple_choice, dropdown, and ranking questions.")
 		choices?: Choice[];
@@ -247,8 +251,8 @@ namespace CoreSystem.Forms {
 	}
 
 	@doc("The request body for creating/updating a question.")
-	@example(#{ required: true, type: QuestionTypes.shortText, title: "What's your name?", description: "Please enter your name", order: 1 })
-	@example(#{ required: true, type: QuestionTypes.longText, title: "Tell us about yourself", description: "Please share your background and experience", order: 2 })
+	@example(#{ required: true, type: QuestionTypes.shortText, title: "What's your name?", description: "Please enter your **name**", order: 1 })
+	@example(#{ required: true, type: QuestionTypes.longText, title: "Tell us about yourself", description: "Please share your **background** and experience", order: 2 })
 	@example(#{
 		required: true,
 		type: QuestionTypes.singleChoice,
@@ -341,8 +345,8 @@ namespace CoreSystem.Forms {
 		@doc("What is the question.")
 		title: string;
 
-		@doc("More details of this question.")
-		description: string;
+		@doc("The question description in Markdown, edited and stored by the admin interface.")
+		description: CoreSystem.MarkdownContent;
 
 		@doc("What is the number of this question in the form.")
 		order: int32;

--- a/src/form/question/operations.tsp
+++ b/src/form/question/operations.tsp
@@ -4,7 +4,7 @@ using Http;
 namespace CoreSystem.Forms {
 	// for form edit - question management
 	@summary("Create Question")
-	@doc("Create a new question for a specific section. Description fields in the request body should be sent as Markdown.")
+	@doc("Create a new question for a specific section. Description fields in the request body should be sent as ProseMirror JSON from the Tiptap editor.")
 	@route("/sections/{sectionId}/questions")
 	@post
 	op createQuestion(@path sectionId: uuid, @body q: QuestionRequest): {
@@ -13,7 +13,7 @@ namespace CoreSystem.Forms {
 	};
 
 	@summary("Update Question")
-	@doc("Update an existing question by its unique identifier. Description fields in the request body should be sent as Markdown.")
+	@doc("Update an existing question by its unique identifier. Description fields in the request body should be sent as ProseMirror JSON from the Tiptap editor.")
 	@route("/sections/{sectionId}/questions/{questionId}")
 	@put
 	op updateQuestion(@path sectionId: uuid, @path questionId: uuid, @body q: QuestionRequest): QuestionResponse;

--- a/src/form/question/operations.tsp
+++ b/src/form/question/operations.tsp
@@ -4,7 +4,7 @@ using Http;
 namespace CoreSystem.Forms {
 	// for form edit - question management
 	@summary("Create Question")
-	@doc("Create a new question for a specific section.")
+	@doc("Create a new question for a specific section. Description fields in the request body should be sent as Markdown.")
 	@route("/sections/{sectionId}/questions")
 	@post
 	op createQuestion(@path sectionId: uuid, @body q: QuestionRequest): {
@@ -13,7 +13,7 @@ namespace CoreSystem.Forms {
 	};
 
 	@summary("Update Question")
-	@doc("Update an existing question by its unique identifier.")
+	@doc("Update an existing question by its unique identifier. Description fields in the request body should be sent as Markdown.")
 	@route("/sections/{sectionId}/questions/{questionId}")
 	@put
 	op updateQuestion(@path sectionId: uuid, @path questionId: uuid, @body q: QuestionRequest): QuestionResponse;

--- a/src/models.tsp
+++ b/src/models.tsp
@@ -1,4 +1,12 @@
 namespace CoreSystem {
 	@format("uuid")
 	scalar uuid extends string;
+
+	@doc("Markdown source text edited and stored by the admin interface.")
+	@format("markdown")
+	scalar MarkdownContent extends string;
+
+	@doc("HTML rendered from Markdown for frontend display.")
+	@format("html")
+	scalar HtmlContent extends string;
 }

--- a/src/models.tsp
+++ b/src/models.tsp
@@ -2,11 +2,43 @@ namespace CoreSystem {
 	@format("uuid")
 	scalar uuid extends string;
 
-	@doc("Markdown source text edited and stored by the admin interface.")
-	@format("markdown")
-	scalar MarkdownContent extends string;
+	@doc("A ProseMirror document JSON payload used by Tiptap editors.")
+	model ProseMirrorDocument {
+		@doc("The root node type. Always `doc` for a ProseMirror document.")
+		type: "doc";
 
-	@doc("HTML rendered from Markdown for frontend display.")
+		@doc("Child nodes in the ProseMirror document.")
+		content?: ProseMirrorNode[];
+	}
+
+	@doc("A ProseMirror node.")
+	model ProseMirrorNode {
+		@doc("The node type, such as `paragraph`, `heading`, or `text`.")
+		type: string;
+
+		@doc("Text content for text nodes.")
+		text?: string;
+
+		@doc("Node attributes.")
+		attrs?: Record<unknown>;
+
+		@doc("Child nodes of this node.")
+		content?: ProseMirrorNode[];
+
+		@doc("Marks applied to this node, such as bold or italic.")
+		marks?: ProseMirrorMark[];
+	}
+
+	@doc("A ProseMirror mark.")
+	model ProseMirrorMark {
+		@doc("The mark type, such as `bold`, `italic`, or `link`.")
+		type: string;
+
+		@doc("Mark attributes.")
+		attrs?: Record<unknown>;
+	}
+
+	@doc("HTML rendered from ProseMirror content for frontend display.")
 	@format("html")
 	scalar HtmlContent extends string;
 }


### PR DESCRIPTION
## Type of changes
- Feature
## Purpose
- Support Tiptap-based rich text editing for form, section, and question descriptions in the admin panel
- Store ProseMirror JSON and generated HTML for frontend preview and form rendering
## Additional Information
- Admin editors now work with Tiptap
- Saved content is submitted as ProseMirror JSON
- Backend persists both ProseMirror JSON and rendered HTML
- Frontend uses the stored HTML for preview and display during form filling