### PR TITLE
Document question order shifting behavior for create, update, and delete operations

### DIFF
--- a/src/form/question/models.tsp
+++ b/src/form/question/models.tsp
@@ -348,7 +348,7 @@ namespace CoreSystem.Forms {
 		@doc("The question description as ProseMirror JSON, edited in Tiptap and sent by the admin interface.")
 		description: CoreSystem.ProseMirrorDocument;
 
-		@doc("What is the number of this question in the form.")
+		@doc("The desired position of this question within the section (1-indexed). On create, clamped to `[1, currentCount + 1]`; on update, clamped to `[1, totalCount]`. The server automatically shifts other questions to maintain a contiguous order sequence.")
 		order: int32;
 
 		@doc("Available choice options for single_choice, multiple_choice, dropdown, and ranking questions.")

--- a/src/form/question/operations.tsp
+++ b/src/form/question/operations.tsp
@@ -4,7 +4,11 @@ using Http;
 namespace CoreSystem.Forms {
 	// for form edit - question management
 	@summary("Create Question")
-	@doc("Create a new question for a specific section. Description fields in the request body should be sent as ProseMirror JSON from the Tiptap editor.")
+	@doc("""
+		Create a new question for a specific section. Description fields in the request body should be sent as ProseMirror JSON from the Tiptap editor.
+
+		The `order` field specifies where to insert the question within the section. The value is clamped to the valid range `[1, currentCount + 1]`. If the question is inserted in the middle (i.e., not appended at the end), all existing questions at or after the specified position are shifted down by one to make room for the new question.
+		""")
 	@route("/sections/{sectionId}/questions")
 	@post
 	op createQuestion(@path sectionId: uuid, @body q: QuestionRequest): {
@@ -13,13 +17,21 @@ namespace CoreSystem.Forms {
 	};
 
 	@summary("Update Question")
-	@doc("Update an existing question by its unique identifier. Description fields in the request body should be sent as ProseMirror JSON from the Tiptap editor.")
+	@doc("""
+		Update an existing question by its unique identifier. Description fields in the request body should be sent as ProseMirror JSON from the Tiptap editor.
+
+		If the `order` field differs from the question's current position, the question is moved to the new position (clamped to `[1, totalCount]`). All questions between the old and new positions are shifted accordingly to maintain a contiguous order sequence.
+		""")
 	@route("/sections/{sectionId}/questions/{questionId}")
 	@put
 	op updateQuestion(@path sectionId: uuid, @path questionId: uuid, @body q: QuestionRequest): QuestionResponse;
 
 	@summary("Delete Question")
-	@doc("Delete an existing question by its unique identifier.")
+	@doc("""
+		Delete an existing question by its unique identifier.
+
+		After deletion, all remaining questions in the same section with a higher order value are shifted up by one to maintain a contiguous order sequence without gaps.
+		""")
 	@route("/sections/{sectionId}/questions/{questionId}")
 	@delete
 	op deleteQuestion(@path sectionId: uuid, @path questionId: uuid): {


### PR DESCRIPTION
## Type of changes

- Docs

## Purpose

- Document the automatic order shifting behavior for question CRUD operations in API spec
- Clarify the `order` field semantics (1-indexed, clamping range) in `QuestionRequest` model

## Additional Information

The backend already handles order management correctly (shift on insert, reorder on update, reindex on delete), but the API spec had no documentation about this behavior. This makes it explicit for API consumers:

- **Create**: `order` clamped to `[1, currentCount + 1]`; existing questions at or after the position are shifted down by one.
- **Update**: if `order` differs from current position, the question is moved and questions between old/new positions are shifted accordingly.
- **Delete**: remaining questions with higher order are shifted up by one to close the gap.

Files changed:
- `src/form/question/operations.tsp` — expanded `@doc` for `createQuestion`, `updateQuestion`, `deleteQuestion`
- `src/form/question/models.tsp` — improved `@doc` for `QuestionRequest.order` field