### PR TITLE
[CORE-295] Add highlight endpoints and extend response list with count fields

### DIFF
--- a/main.tsp
+++ b/main.tsp
@@ -74,6 +74,10 @@ import "./src/form/response/operations.tsp";
 import "./src/form/answer/models.tsp";
 import "./src/form/answer/operations.tsp";
 
+// --- Highlight ---
+import "./src/form/highlight/models.tsp";
+import "./src/form/highlight/operations.tsp";
+
 // ═════════════════════════════════════════════════
 // === File ===
 // ═════════════════════════════════════════════════

--- a/scenarios/user-journey/form-lifecycle/06-response-creation.http
+++ b/scenarios/user-journey/form-lifecycle/06-response-creation.http
@@ -1131,6 +1131,11 @@ GET {{BASE_URL}}/forms/{{formId}}/responses
     test('Form responses listed', () => {
         const data = JSON.parse(response.body);
         equal(data.formId, formId, 'Form ID should match');
+        equal(typeof data.totalCount, 'number', 'totalCount should be a number');
+        equal(typeof data.draftCount, 'number', 'draftCount should be a number');
+        equal(typeof data.submittedCount, 'number', 'submittedCount should be a number');
+        equal(data.totalCount, data.draftCount + data.submittedCount, 'totalCount should equal draftCount + submittedCount');
+        equal(data.submittedCount >= 1, true, 'Should have at least one submitted response');
         equal(Array.isArray(data.responses), true, 'Responses should be an array');
         equal(data.responses.length >= 1, true, 'Should have at least one response');
         

--- a/scenarios/user-journey/form-lifecycle/06a-form-highlight.http
+++ b/scenarios/user-journey/form-lifecycle/06a-form-highlight.http
@@ -1,0 +1,208 @@
+# ============================================
+# Phase 6a: Form Highlight Lifecycle
+# ============================================
+# This file tests form highlight configuration and statistics:
+# - Get the unconfigured highlight state
+# - Set a choice-based question as the highlight
+# - Verify per-choice response counts
+# - Patch the display title
+# - Clear the highlight
+
+# Import setup from Phase 6
+# @import ./06-response-creation.http
+
+###
+
+# ============================================
+# Get Highlight Before Configuration
+# ============================================
+# @name getHighlightBeforeConfiguration
+# @ref listFormResponses
+GET {{BASE_URL}}/forms/{{formId}}/highlight
+
+{{
+    test.status(200);
+    test.hasResponseBody();
+
+    const { equal } = require('assert');
+
+    test('Unconfigured highlight returns null fields and empty choices', () => {
+        const data = JSON.parse(response.body);
+        equal(data.questionId, null, 'questionId should be null before configuration');
+        equal(data.questionTitle, null, 'questionTitle should be null before configuration');
+        equal(data.displayTitle, null, 'displayTitle should be null before configuration');
+        equal(Array.isArray(data.choices), true, 'choices should be an array');
+        equal(data.choices.length, 0, 'choices should be empty before configuration');
+    });
+}}
+
+###
+
+# ============================================
+# Set Form Highlight
+# ============================================
+# @name setFormHighlight
+# @ref getHighlightBeforeConfiguration
+PUT {{BASE_URL}}/forms/{{formId}}/highlight
+Content-Type: application/json
+
+{
+    "questionId": "{{singleChoiceQuestionId}}",
+    "displayTitle": "Work Location Highlight"
+}
+
+{{
+    test.status(200);
+    test.hasResponseBody();
+
+    const { equal } = require('assert');
+
+    test('Choice-based question is configured as highlight', () => {
+        const data = JSON.parse(response.body);
+        equal(data.questionId, singleChoiceQuestionId, 'Highlight question should match request');
+        equal(data.questionTitle, 'What is your preferred work location?', 'questionTitle should come from the question');
+        equal(data.displayTitle, 'Work Location Highlight', 'displayTitle should use the configured title');
+        equal(Array.isArray(data.choices), true, 'choices should be an array');
+        equal(data.choices.length, singleChoiceOptions.length, 'choices should include all options');
+
+        const remote = data.choices.find(c => c.choiceId === singleChoiceOptions[0].id);
+        const onSite = data.choices.find(c => c.choiceId === singleChoiceOptions[1].id);
+        const hybrid = data.choices.find(c => c.choiceId === singleChoiceOptions[2].id);
+
+        equal(remote !== undefined, true, 'Remote choice should be present');
+        equal(remote.name, 'Remote', 'Remote choice name should match');
+        equal(remote.count, 1, 'Remote should have one response');
+
+        equal(onSite !== undefined, true, 'On-site choice should be present');
+        equal(onSite.name, 'On-site', 'On-site choice name should match');
+        equal(onSite.count, 0, 'On-site should have no responses');
+
+        equal(hybrid !== undefined, true, 'Hybrid choice should be present');
+        equal(hybrid.name, 'Hybrid', 'Hybrid choice name should match');
+        equal(hybrid.count, 0, 'Hybrid should have no responses');
+    });
+}}
+
+###
+
+# ============================================
+# Get Configured Form Highlight
+# ============================================
+# @name getConfiguredFormHighlight
+# @ref setFormHighlight
+GET {{BASE_URL}}/forms/{{formId}}/highlight
+
+{{
+    test.status(200);
+    test.hasResponseBody();
+
+    const { equal } = require('assert');
+
+    test('Configured highlight persists and returns response statistics', () => {
+        const data = JSON.parse(response.body);
+        equal(data.questionId, singleChoiceQuestionId, 'Highlight question should persist');
+        equal(data.questionTitle, 'What is your preferred work location?', 'questionTitle should match');
+        equal(data.displayTitle, 'Work Location Highlight', 'displayTitle should persist');
+        equal(Array.isArray(data.choices), true, 'choices should be an array');
+        equal(data.choices.length, singleChoiceOptions.length, 'choices should include all options');
+
+        const totalChoiceCount = data.choices.reduce((sum, choice) => sum + choice.count, 0);
+        equal(totalChoiceCount, 1, 'Choice counts should include the submitted response once');
+    });
+}}
+
+###
+
+# ============================================
+# Patch Form Highlight Display Title
+# ============================================
+# @name patchFormHighlightTitle
+# @ref getConfiguredFormHighlight
+PATCH {{BASE_URL}}/forms/{{formId}}/highlight
+Content-Type: application/json
+
+{
+    "displayTitle": "Updated Work Location Highlight"
+}
+
+{{
+    test.status(200);
+    test.hasResponseBody();
+
+    const { equal } = require('assert');
+
+    test('Highlight display title is updated without changing question', () => {
+        const data = JSON.parse(response.body);
+        equal(data.questionId, singleChoiceQuestionId, 'Highlight question should not change');
+        equal(data.questionTitle, 'What is your preferred work location?', 'questionTitle should still come from the question');
+        equal(data.displayTitle, 'Updated Work Location Highlight', 'displayTitle should be updated');
+    });
+}}
+
+###
+
+# ============================================
+# Patch Form Highlight Display Title to Null
+# ============================================
+# @name patchFormHighlightTitleToNull
+# @ref patchFormHighlightTitle
+PATCH {{BASE_URL}}/forms/{{formId}}/highlight
+Content-Type: application/json
+
+{
+    "displayTitle": null
+}
+
+{{
+    test.status(200);
+    test.hasResponseBody();
+
+    const { equal } = require('assert');
+
+    test('Null display title falls back to question title', () => {
+        const data = JSON.parse(response.body);
+        equal(data.questionId, singleChoiceQuestionId, 'Highlight question should not change');
+        equal(data.questionTitle, 'What is your preferred work location?', 'questionTitle should match');
+        equal(data.displayTitle, 'What is your preferred work location?', 'displayTitle should fall back to questionTitle');
+    });
+}}
+
+###
+
+# ============================================
+# Clear Form Highlight
+# ============================================
+# @name clearFormHighlight
+# @ref patchFormHighlightTitleToNull
+DELETE {{BASE_URL}}/forms/{{formId}}/highlight
+
+{{
+    test.status(204);
+}}
+
+###
+
+# ============================================
+# Get Highlight After Clear
+# ============================================
+# @name getHighlightAfterClear
+# @ref clearFormHighlight
+GET {{BASE_URL}}/forms/{{formId}}/highlight
+
+{{
+    test.status(200);
+    test.hasResponseBody();
+
+    const { equal } = require('assert');
+
+    test('Cleared highlight returns unconfigured state', () => {
+        const data = JSON.parse(response.body);
+        equal(data.questionId, null, 'questionId should be null after clearing');
+        equal(data.questionTitle, null, 'questionTitle should be null after clearing');
+        equal(data.displayTitle, null, 'displayTitle should be null after clearing');
+        equal(Array.isArray(data.choices), true, 'choices should be an array');
+        equal(data.choices.length, 0, 'choices should be empty after clearing');
+    });
+}}
+
+###

--- a/scenarios/user-journey/form-lifecycle/README.md
+++ b/scenarios/user-journey/form-lifecycle/README.md
@@ -11,6 +11,7 @@ These tests cover the full journey of a form from creation to archival, includin
 - Basic workflow setup
 - Form publishing
 - Response submission and management
+- Highlight configuration and statistics
 - Form archival
 
 ## Test Files
@@ -51,31 +52,16 @@ Execute tests in the following order:
    - Final response submission
    - Verify response status transitions
 
-7. **`07-optional-google-sheet.http`** - Google Sheet Integration _(Coming soon)_
-   - Non-blocking tests for Google Sheet features
-   - Service account email retrieval
-   - Failures logged as warnings only
+7. **`06a-form-highlight.http`** - Form Highlight Lifecycle
+   - Verify unconfigured highlight state
+   - Set a choice-based highlight question
+   - Verify per-choice response counts
+   - Patch and clear highlight configuration
 
-8. **`08-response-management.http`** - Response Management _(Coming soon)_
-   - List and view responses
-   - Response deletion
-
-9. **`09-form-archival.http`** - Form Archival & Cleanup _(Coming soon)_
-   - Non-blocking tests for Google Sheet features
-   - Service account email retrieval
-   - Failures logged as warnings only
-
-10. **`07-response-submission.http`** - Form Submission _(Coming soon)_
-    - Response creation
-    - Answer submission for all question types
-
-11. **`08-response-management.http`** - Response Management _(Coming soon)_
-    - List and view responses
-    - Response deletion
-
-12. **`09-form-archival.http`** - Form Archival & Cleanup _(Coming soon)_
-    - Archive form
-    - Verify archived state
+8. **`07-form-archiving.http`** - Form Archival & Cleanup
+   - Archive form
+   - Verify archived state in listings
+   - Unarchive and re-publish form
 
 ## Setup
 

--- a/scenarios/user-journey/form-workflow-condition/04-response-creation.http
+++ b/scenarios/user-journey/form-workflow-condition/04-response-creation.http
@@ -441,6 +441,11 @@ GET {{BASE_URL}}/forms/{{formId}}/responses
     test('Form responses listed', () => {
         const data = JSON.parse(response.body);
         equal(data.formId, formId, 'Form ID should match');
+        equal(typeof data.totalCount, 'number', 'totalCount should be a number');
+        equal(typeof data.draftCount, 'number', 'draftCount should be a number');
+        equal(typeof data.submittedCount, 'number', 'submittedCount should be a number');
+        equal(data.totalCount, data.draftCount + data.submittedCount, 'totalCount should equal draftCount + submittedCount');
+        equal(data.submittedCount >= 1, true, 'Should have at least one submitted response');
         equal(Array.isArray(data.responses), true, 'Responses should be an array');
         equal(data.responses.length >= 1, true, 'Should have at least one response');
         

--- a/scenarios/user-journey/negative-form-lifecycle/07-highlight-negative.http
+++ b/scenarios/user-journey/negative-form-lifecycle/07-highlight-negative.http
@@ -1,0 +1,107 @@
+# ============================================
+# Negative Form Highlight - Error paths for highlight operations
+# ============================================
+# Variables (formId, shortTextQuestionId, etc.) come from the positive flow.
+
+# @import ../form-lifecycle/06a-form-highlight.http
+
+###
+
+# ============================================
+# Set highlight to non-choice question (expect 400)
+# ============================================
+# @name setHighlightNonChoiceQuestion
+# @ref getHighlightAfterClear
+PUT {{BASE_URL}}/forms/{{formId}}/highlight
+Content-Type: application/json
+
+{
+    "questionId": "{{shortTextQuestionId}}",
+    "displayTitle": "Invalid Highlight"
+}
+
+?? status == 400
+{{
+    test.hasResponseBody();
+
+    const { equal } = require('assert');
+
+    test('Error body indicates validation/problem', () => {
+        const data = JSON.parse(response.body);
+        equal(data.status, 400, 'Status in body should be 400');
+        equal(data.title, 'Validation Problem', 'Response title should be Validation Problem');
+    });
+}}
+
+###
+
+# ============================================
+# Get highlight for non-existent form ID (expect 404)
+# ============================================
+# @name getHighlightNonExistentForm
+# @ref setHighlightNonChoiceQuestion
+GET {{BASE_URL}}/forms/00000000-0000-0000-0000-000000000000/highlight
+
+?? status == 404
+{{
+    test.hasResponseBody();
+
+    const { equal } = require('assert');
+
+    test('Error body indicates Not Found', () => {
+        const data = JSON.parse(response.body);
+        equal(data.title, 'Not Found', 'Response title should be Not Found');
+        equal(data.status, 404, 'Status in body should be 404');
+    });
+}}
+
+###
+
+# ============================================
+# Patch highlight before one is configured (expect 404)
+# ============================================
+# @name patchHighlightBeforeConfiguration
+# @ref getHighlightNonExistentForm
+PATCH {{BASE_URL}}/forms/{{formId}}/highlight
+Content-Type: application/json
+
+{
+    "displayTitle": "No Highlight Exists"
+}
+
+?? status == 404
+{{
+    test.hasResponseBody();
+
+    const { equal } = require('assert');
+
+    test('Error body indicates Not Found', () => {
+        const data = JSON.parse(response.body);
+        equal(data.title, 'Not Found', 'Response title should be Not Found');
+        equal(data.status, 404, 'Status in body should be 404');
+    });
+}}
+
+###
+
+# ============================================
+# Clear highlight before one is configured (expect 404)
+# ============================================
+# @name clearHighlightBeforeConfiguration
+# @ref patchHighlightBeforeConfiguration
+DELETE {{BASE_URL}}/forms/{{formId}}/highlight
+
+?? status == 404
+{{
+    test.hasResponseBody();
+
+    const { equal } = require('assert');
+
+    test('Error body indicates Not Found', () => {
+        const data = JSON.parse(response.body);
+        equal(data.title, 'Not Found', 'Response title should be Not Found');
+        equal(data.status, 404, 'Status in body should be 404');
+    });
+}}
+
+###

--- a/scenarios/user-journey/negative-form-lifecycle/README.md
+++ b/scenarios/user-journey/negative-form-lifecycle/README.md
@@ -9,6 +9,7 @@ Negative tests cover:
 - **404** – Not Found (invalid slugs, non-existent form/section/question/response IDs)
 - **400** – Validation / Bad Request (missing required fields, invalid types, invalid values)
 - **403** – Forbidden (e.g. creating a form under an org the user is not a member of)
+- Highlight error paths for invalid question types and missing highlight resources
 
 These scenarios **depend on the positive form lifecycle** (`../form-lifecycle/`). Each negative file imports the corresponding positive flow to get auth, org, form, section, question, and response variables, then runs only the negative cases.
 
@@ -50,6 +51,11 @@ Execute tests in the following order:
    - Imports `../form-lifecycle/06-response-creation.http`
    - Wrong questionType for question, invalid value type, value out of range → 400
    - Non-existent response/question IDs, invalid answer payloads → 404 / 400
+
+8. **`07-highlight-negative.http`** – Highlight Error Paths
+   - Imports `../form-lifecycle/06a-form-highlight.http`
+   - Non-choice highlight question → 400
+   - Non-existent form and missing highlight configuration → 404
 
 ## Setup
 

--- a/src/form/highlight/models.tsp
+++ b/src/form/highlight/models.tsp
@@ -1,0 +1,51 @@
+namespace CoreSystem.Forms {
+	@doc("A choice with its response count for highlight statistics.")
+	@example(#{ choiceId: "f421cfc2-2b84-4da9-9629-011af609935a", name: "大一", count: 42 })
+	model HighlightChoice {
+		@doc("The unique identifier of the choice.")
+		choiceId: uuid;
+
+		@doc("The name/text of the choice.")
+		name: string;
+
+		@doc("Number of responses (draft + submitted) that selected this choice.")
+		count: int32;
+	}
+
+	@doc("Response model for a form's highlight question statistics. When no highlight is configured, questionId is null and all other fields are null or empty.")
+	@example(#{
+		questionId: "ee894524-4bd8-4a64-8fd2-a53b39ca94cd",
+		questionTitle: "你的年級是？",
+		displayTitle: "年級分佈統計",
+		choices: #[
+			#{ choiceId: "f421cfc2-2b84-4da9-9629-011af609935a", name: "大一", count: 42 },
+			#{ choiceId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890", name: "大二", count: 30 },
+		],
+	})
+	@example(#{ questionId: null, questionTitle: null, displayTitle: null, choices: #[] })
+	model HighlightResponse {
+		@doc("The highlighted question's unique identifier. Null if no highlight is configured.")
+		questionId: uuid | null;
+
+		@doc("The current title of the highlighted question, fetched from the question. Null if no highlight is configured.")
+		questionTitle: string | null;
+
+		@doc("The display title shown on the dashboard. Equals stored custom title if set, otherwise falls back to questionTitle. Null if no highlight is configured.")
+		displayTitle: string | null;
+
+		@doc("Response counts per choice option. Empty array if no highlight is configured.")
+		choices: HighlightChoice[];
+	}
+
+	@doc("Request body for setting or clearing a form's highlight question.")
+	@example(#{ questionId: "ee894524-4bd8-4a64-8fd2-a53b39ca94cd", displayTitle: "年級分佈統計" })
+	@example(#{ questionId: "ee894524-4bd8-4a64-8fd2-a53b39ca94cd" })
+	@example(#{ questionId: null })
+	model HighlightRequest {
+		@doc("The question ID to highlight. Must be a choice-based question (singleChoice, multipleChoice, dropdown, detailedMultipleChoice). Set to null to clear the entire highlight.")
+		questionId: uuid | null;
+
+		@doc("Custom display title for the highlight. If omitted or null, the backend falls back to the question's current title. Ignored when questionId is null.")
+		displayTitle?: string | null;
+	}
+}

--- a/src/form/highlight/models.tsp
+++ b/src/form/highlight/models.tsp
@@ -22,7 +22,6 @@ namespace CoreSystem.Forms {
 			#{ choiceId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890", name: "大二", count: 30 },
 		],
 	})
-	@example(#{ questionId: null, questionTitle: null, displayTitle: null, choices: #[] })
 	model HighlightResponse {
 		@doc("The highlighted question's unique identifier. Null if no highlight is configured.")
 		questionId: uuid | null;
@@ -39,8 +38,6 @@ namespace CoreSystem.Forms {
 
 	@doc("Request body for setting or clearing a form's highlight question.")
 	@example(#{ questionId: "ee894524-4bd8-4a64-8fd2-a53b39ca94cd", displayTitle: "年級分佈統計" })
-	@example(#{ questionId: "ee894524-4bd8-4a64-8fd2-a53b39ca94cd" })
-	@example(#{ questionId: null })
 	model HighlightRequest {
 		@doc("The question ID to highlight. Must be a choice-based question (singleChoice, multipleChoice, dropdown, detailedMultipleChoice). Set to null to clear the entire highlight.")
 		questionId: uuid | null;

--- a/src/form/highlight/models.tsp
+++ b/src/form/highlight/models.tsp
@@ -45,4 +45,11 @@ namespace CoreSystem.Forms {
 		@doc("Custom display title for the highlight. If omitted or null, the backend falls back to the question's current title.")
 		displayTitle?: string | null;
 	}
+
+	@doc("Request body for partially updating a form's highlight.")
+	@example(#{ displayTitle: "Updated highlight title" })
+	model HighlightPatchRequest {
+		@doc("Custom display title for the highlight. Send null to fall back to the question's current title.")
+		displayTitle?: string | null;
+	}
 }

--- a/src/form/highlight/models.tsp
+++ b/src/form/highlight/models.tsp
@@ -36,13 +36,13 @@ namespace CoreSystem.Forms {
 		choices: HighlightChoice[];
 	}
 
-	@doc("Request body for setting or clearing a form's highlight question.")
+	@doc("Request body for setting a form's highlight question.")
 	@example(#{ questionId: "ee894524-4bd8-4a64-8fd2-a53b39ca94cd", displayTitle: "年級分佈統計" })
 	model HighlightRequest {
-		@doc("The question ID to highlight. Must be a choice-based question (singleChoice, multipleChoice, dropdown, detailedMultipleChoice). Set to null to clear the entire highlight.")
-		questionId: uuid | null;
+		@doc("The question ID to highlight. Must be a choice-based question (singleChoice, multipleChoice, dropdown, detailedMultipleChoice).")
+		questionId: uuid;
 
-		@doc("Custom display title for the highlight. If omitted or null, the backend falls back to the question's current title. Ignored when questionId is null.")
+		@doc("Custom display title for the highlight. If omitted or null, the backend falls back to the question's current title.")
 		displayTitle?: string | null;
 	}
 }

--- a/src/form/highlight/operations.tsp
+++ b/src/form/highlight/operations.tsp
@@ -1,0 +1,31 @@
+using Http;
+
+@tag("Forms")
+namespace CoreSystem.Forms {
+	@summary("Get Form Highlight")
+	@doc("Get the highlight question and its response statistics for a specific form. Returns 200 with questionId=null when no highlight is configured.")
+	@route("/forms/{formId}/highlight")
+	@get
+	op getFormHighlight(@path formId: uuid): {
+		@statusCode statusCode: 200;
+		@body response: HighlightResponse;
+	} | {
+		@statusCode statusCode: 404;
+		@body error: NotFound;
+	};
+
+	@summary("Set Form Highlight")
+	@doc("Set, update, or clear the highlight question for a specific form. To clear, send questionId: null. Returns 400 if the question is not a choice-based type (singleChoice, multipleChoice, dropdown, detailedMultipleChoice).")
+	@route("/forms/{formId}/highlight")
+	@put
+	op setFormHighlight(@path formId: uuid, @body req: HighlightRequest): {
+		@statusCode statusCode: 200;
+		@body response: HighlightResponse;
+	} | {
+		@statusCode statusCode: 400;
+		@body error: BadRequest;
+	} | {
+		@statusCode statusCode: 404;
+		@body error: NotFound;
+	};
+}

--- a/src/form/highlight/operations.tsp
+++ b/src/form/highlight/operations.tsp
@@ -15,7 +15,7 @@ namespace CoreSystem.Forms {
 	};
 
 	@summary("Set Form Highlight")
-	@doc("Set, update, or clear the highlight question for a specific form. To clear, send questionId: null. Returns 400 if the question is not a choice-based type (singleChoice, multipleChoice, dropdown, detailedMultipleChoice).")
+	@doc("Set or update the highlight question for a specific form. Returns 400 if the question is not a choice-based type (singleChoice, multipleChoice, dropdown, detailedMultipleChoice).")
 	@route("/forms/{formId}/highlight")
 	@put
 	op setFormHighlight(@path formId: uuid, @body req: HighlightRequest): {
@@ -24,6 +24,17 @@ namespace CoreSystem.Forms {
 	} | {
 		@statusCode statusCode: 400;
 		@body error: BadRequest;
+	} | {
+		@statusCode statusCode: 404;
+		@body error: NotFound;
+	};
+
+	@summary("Clear Form Highlight")
+	@doc("Clear the highlight question for a specific form.")
+	@route("/forms/{formId}/highlight")
+	@delete
+	op clearFormHighlight(@path formId: uuid): {
+		@statusCode statusCode: 204;
 	} | {
 		@statusCode statusCode: 404;
 		@body error: NotFound;

--- a/src/form/highlight/operations.tsp
+++ b/src/form/highlight/operations.tsp
@@ -29,6 +29,21 @@ namespace CoreSystem.Forms {
 		@body error: NotFound;
 	};
 
+	@summary("Update Form Highlight")
+	@doc("Partially update the configured highlight for a specific form. Currently supports updating displayTitle only. Send displayTitle: null to fall back to the question's current title.")
+	@route("/forms/{formId}/highlight")
+	@patch(#{ implicitOptionality: false })
+	op updateFormHighlight(@path formId: uuid, @body req: HighlightPatchRequest): {
+		@statusCode statusCode: 200;
+		@body response: HighlightResponse;
+	} | {
+		@statusCode statusCode: 400;
+		@body error: BadRequest;
+	} | {
+		@statusCode statusCode: 404;
+		@body error: NotFound;
+	};
+
 	@summary("Clear Form Highlight")
 	@doc("Clear the highlight question for a specific form.")
 	@route("/forms/{formId}/highlight")

--- a/src/form/response/models.tsp
+++ b/src/form/response/models.tsp
@@ -47,10 +47,25 @@ namespace CoreSystem.Responses {
 	}
 
 	@doc("Response model for listing all responses of a form")
-	@example(#{ formId: "9a843aa0-8451-4e3b-b6a0-8c0e994e9040", responses: #[] })
+	@example(#{
+		formId: "9a843aa0-8451-4e3b-b6a0-8c0e994e9040",
+		totalCount: 150,
+		draftCount: 30,
+		submittedCount: 120,
+		responses: #[],
+	})
 	model ListResponse {
 		@doc("The form ID.")
 		formId: uuid;
+
+		@doc("Total number of responses for this form.")
+		totalCount: int32;
+
+		@doc("Number of responses in draft state.")
+		draftCount: int32;
+
+		@doc("Number of submitted responses.")
+		submittedCount: int32;
 
 		@doc("All responses for this form.")
 		responses: Response[];


### PR DESCRIPTION
## Type of changes

Docs

## Purpose

- Add `GET /forms/{formId}/highlight` endpoint for retrieving the configured form highlight and its response statistics
- Add `PUT /forms/{formId}/highlight` endpoint for setting or replacing the highlighted question
- Add `PATCH /forms/{formId}/highlight` endpoint for partially updating the configured highlight, currently `displayTitle`
- Add `DELETE /forms/{formId}/highlight` endpoint for clearing the configured highlight
- Extend `GET /forms/{formId}/responses` response with `totalCount`, `draftCount`, and `submittedCount`

## Additional Information

Highlight design decisions:

- `GET /forms/{formId}/highlight` always returns `200` when the form exists
- `questionId: null` in the GET response means no highlight is configured
- Unconfigured highlight state is not treated as `404`; `404` is reserved for missing form resources
- Only choice-based questions can be highlighted:
  - `singleChoice`
  - `multipleChoice`
  - `dropdown`
  - `detailedMultipleChoice`
- Non-choice-based questions return `400`
- `PUT` sets or replaces the highlighted question and requires `questionId`
- `PATCH` updates the existing highlight without changing the highlighted question
- `displayTitle` is optional in `PUT`
- `displayTitle: null` in `PUT` or `PATCH` falls back to the question's current title, avoiding stale title snapshots
- Clearing highlight is handled by `DELETE /forms/{formId}/highlight`
- After clearing, GET returns `questionId`, `questionTitle`, and `displayTitle` as `null`, with `choices: []`