### PR TITLE
[CORE-275] Add creator and last editor in form response

### DIFF
--- a/src/form/models.tsp
+++ b/src/form/models.tsp
@@ -69,7 +69,8 @@ namespace CoreSystem.Forms {
 		previewMessage: "Join us for an exciting journey",
 		status: FormStatus.published,
 		unitId: "d26e9c90-4747-496b-9953-7e7c4f97643f",
-		lastEditor: "3c5fa073-7b97-43a3-bc44-ddc98f390a08",
+		lastEditor: "john_doe",
+		creator: "john_doe",
 		deadline: utcDateTime.fromISO("2025-03-31T23:59:59Z"),
 		publishTime: utcDateTime.fromISO("2025-02-01T00:00:00Z"),
 		messageAfterSubmission: "Thank you for your application! We'll get back to you soon.",
@@ -102,8 +103,11 @@ namespace CoreSystem.Forms {
 		@doc("The unit this form belongs to.")
 		unitId: uuid;
 
-		@doc("The user who last editted the form.")
-		lastEditor: uuid;
+		@doc("The username of the user who last editted the form.")
+		lastEditor: string;
+
+		@doc("The username of the user who created the form")
+		creator: string;
 
 		@doc("(Optional) Deadline for form completion. If not specified, returns null.")
 		deadline?: utcDateTime;

--- a/src/form/models.tsp
+++ b/src/form/models.tsp
@@ -69,8 +69,7 @@ namespace CoreSystem.Forms {
 		previewMessage: "Join us for an exciting journey",
 		status: FormStatus.published,
 		unitId: "d26e9c90-4747-496b-9953-7e7c4f97643f",
-		lastEditor: "john_doe",
-		creator: "john_doe",
+		lastEditor: "3c5fa073-7b97-43a3-bc44-ddc98f390a08",
 		deadline: utcDateTime.fromISO("2025-03-31T23:59:59Z"),
 		publishTime: utcDateTime.fromISO("2025-02-01T00:00:00Z"),
 		messageAfterSubmission: "Thank you for your application! We'll get back to you soon.",
@@ -103,11 +102,8 @@ namespace CoreSystem.Forms {
 		@doc("The unit this form belongs to.")
 		unitId: uuid;
 
-		@doc("The username of the user who last editted the form.")
-		lastEditor: string;
-
-		@doc("The username of the user who created the form")
-		creator: string;
+		@doc("The user who last editted the form.")
+		lastEditor: uuid;
 
 		@doc("(Optional) Deadline for form completion. If not specified, returns null.")
 		deadline?: utcDateTime;

--- a/src/form/models.tsp
+++ b/src/form/models.tsp
@@ -69,8 +69,8 @@ namespace CoreSystem.Forms {
 		previewMessage: "Join us for an exciting journey",
 		status: FormStatus.published,
 		unitId: "d26e9c90-4747-496b-9953-7e7c4f97643f",
-		lastEditor: "John Doe",
-		creator: "John Doe",
+		lastEditor: "john_doe",
+		creator: "john_doe",
 		deadline: utcDateTime.fromISO("2025-03-31T23:59:59Z"),
 		publishTime: utcDateTime.fromISO("2025-02-01T00:00:00Z"),
 		messageAfterSubmission: "Thank you for your application! We'll get back to you soon.",
@@ -103,10 +103,10 @@ namespace CoreSystem.Forms {
 		@doc("The unit this form belongs to.")
 		unitId: uuid;
 
-		@doc("The name of the user who last editted the form.")
+		@doc("The username of the user who last editted the form.")
 		lastEditor: string;
 
-		@doc("The name of the user who created the form")
+		@doc("The username of the user who created the form")
 		creator: string;
 
 		@doc("(Optional) Deadline for form completion. If not specified, returns null.")

--- a/src/form/models.tsp
+++ b/src/form/models.tsp
@@ -103,11 +103,11 @@ namespace CoreSystem.Forms {
 		@doc("The unit this form belongs to.")
 		unitId: uuid;
 
-		@doc("The user who last editted the form.")
-		lastEditor: User;
+		@doc("The name of the user who last editted the form.")
+		lastEditor: string;
 
-		@doc("The user who created the form")
-		creator: User;
+		@doc("The name of the user who created the form")
+		creator: string;
 
 		@doc("(Optional) Deadline for form completion. If not specified, returns null.")
 		deadline?: utcDateTime;

--- a/src/form/models.tsp
+++ b/src/form/models.tsp
@@ -15,12 +15,20 @@ namespace CoreSystem.Forms {
 
 	@doc("The request body for creating/updating a form.")
 	@example(#{
+		creator: "3c5fa073-7b97-43a3-bc44-ddc98f390a08",
+		lastEditor: "3c5fa073-7b97-43a3-bc44-ddc98f390a08",
 		title: "Enter SDC Form",
 		description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "If you want to join us, just fill in this form!" }] }] },
 		messageAfterSubmission: "Thank you for your submission!",
 		visibility: FormVisibility.public,
 	})
 	model FormRequest {
+		@doc("The user who created the form. Required on create; should be omitted on update.")
+		creator?: uuid;
+
+		@doc("The user who last edited the form. Required on create and should be updated on update.")
+		lastEditor?: uuid;
+
 		@doc("The title of the form.")
 		title: string;
 
@@ -52,7 +60,7 @@ namespace CoreSystem.Forms {
 		visibility: FormVisibility;
 	}
 
-	@doc("The structure of a form.")
+	@doc("Response model for a form with creator and last editor user details.")
 	@example(#{
 		id: "9a843aa0-8451-4e3b-b6a0-8c0e994e9040",
 		title: "SDC 2025 Recruitment Form",
@@ -69,7 +77,24 @@ namespace CoreSystem.Forms {
 		previewMessage: "Join us for an exciting journey",
 		status: FormStatus.published,
 		unitId: "d26e9c90-4747-496b-9953-7e7c4f97643f",
-		lastEditor: "3c5fa073-7b97-43a3-bc44-ddc98f390a08",
+		creator: #{
+			id: "3c5fa073-7b97-43a3-bc44-ddc98f390a08",
+			username: "john_doe",
+			name: "John Doe",
+			avatarUrl: "https://avatars.githubusercontent.com/u/12345678",
+			emails: #["john.doe@example.com", "john@gmail.com"],
+			roles: #[CoreSystem.User.Role.user],
+			require_onboarding: true,
+		},
+		lastEditor: #{
+			id: "3c5fa073-7b97-43a3-bc44-ddc98f390a08",
+			username: "john_doe",
+			name: "John Doe",
+			avatarUrl: "https://avatars.githubusercontent.com/u/12345678",
+			emails: #["john.doe@example.com", "john@gmail.com"],
+			roles: #[CoreSystem.User.Role.user],
+			require_onboarding: true,
+		},
 		deadline: utcDateTime.fromISO("2025-03-31T23:59:59Z"),
 		publishTime: utcDateTime.fromISO("2025-02-01T00:00:00Z"),
 		messageAfterSubmission: "Thank you for your application! We'll get back to you soon.",
@@ -80,7 +105,7 @@ namespace CoreSystem.Forms {
 		createdAt: utcDateTime.fromISO("2025-01-15T10:00:00Z"),
 		updatedAt: utcDateTime.fromISO("2025-02-10T14:30:00Z"),
 	})
-	model Form {
+	model FormResponse {
 		@doc("The form's unique identifier.")
 		id: uuid;
 
@@ -102,8 +127,11 @@ namespace CoreSystem.Forms {
 		@doc("The unit this form belongs to.")
 		unitId: uuid;
 
-		@doc("The user who last editted the form.")
-		lastEditor: uuid;
+		@doc("The user who created the form.")
+		creator: CoreSystem.User.User;
+
+		@doc("The user who last edited the form.")
+		lastEditor: CoreSystem.User.User;
 
 		@doc("(Optional) Deadline for form completion. If not specified, returns null.")
 		deadline?: utcDateTime;

--- a/src/form/models.tsp
+++ b/src/form/models.tsp
@@ -69,8 +69,8 @@ namespace CoreSystem.Forms {
 		previewMessage: "Join us for an exciting journey",
 		status: FormStatus.published,
 		unitId: "d26e9c90-4747-496b-9953-7e7c4f97643f",
-		lastEditor: "john_doe",
-		creator: "john_doe",
+		lastEditor: "John Doe",
+		creator: "John Doe",
 		deadline: utcDateTime.fromISO("2025-03-31T23:59:59Z"),
 		publishTime: utcDateTime.fromISO("2025-02-01T00:00:00Z"),
 		messageAfterSubmission: "Thank you for your application! We'll get back to you soon.",
@@ -103,10 +103,10 @@ namespace CoreSystem.Forms {
 		@doc("The unit this form belongs to.")
 		unitId: uuid;
 
-		@doc("The username of the user who last editted the form.")
+		@doc("The name of the user who last editted the form.")
 		lastEditor: string;
 
-		@doc("The username of the user who created the form")
+		@doc("The name of the user who created the form")
 		creator: string;
 
 		@doc("(Optional) Deadline for form completion. If not specified, returns null.")

--- a/src/form/models.tsp
+++ b/src/form/models.tsp
@@ -103,11 +103,11 @@ namespace CoreSystem.Forms {
 		@doc("The unit this form belongs to.")
 		unitId: uuid;
 
-		@doc("The name of the user who last editted the form.")
-		lastEditor: string;
+		@doc("The user who last editted the form.")
+		lastEditor: User;
 
-		@doc("The name of the user who created the form")
-		creator: string;
+		@doc("The user who created the form")
+		creator: User;
 
 		@doc("(Optional) Deadline for form completion. If not specified, returns null.")
 		deadline?: utcDateTime;

--- a/src/form/models.tsp
+++ b/src/form/models.tsp
@@ -79,21 +79,17 @@ namespace CoreSystem.Forms {
 		unitId: "d26e9c90-4747-496b-9953-7e7c4f97643f",
 		creator: #{
 			id: "3c5fa073-7b97-43a3-bc44-ddc98f390a08",
-			username: "john_doe",
 			name: "John Doe",
+			username: "john_doe",
 			avatarUrl: "https://avatars.githubusercontent.com/u/12345678",
 			emails: #["john.doe@example.com", "john@gmail.com"],
-			roles: #[CoreSystem.User.Role.user],
-			require_onboarding: true,
 		},
 		lastEditor: #{
 			id: "3c5fa073-7b97-43a3-bc44-ddc98f390a08",
-			username: "john_doe",
 			name: "John Doe",
+			username: "john_doe",
 			avatarUrl: "https://avatars.githubusercontent.com/u/12345678",
 			emails: #["john.doe@example.com", "john@gmail.com"],
-			roles: #[CoreSystem.User.Role.user],
-			require_onboarding: true,
 		},
 		deadline: utcDateTime.fromISO("2025-03-31T23:59:59Z"),
 		publishTime: utcDateTime.fromISO("2025-02-01T00:00:00Z"),
@@ -128,13 +124,13 @@ namespace CoreSystem.Forms {
 		unitId: uuid;
 
 		@doc("The user who created the form.")
-		creator: CoreSystem.User.User;
+		creator: CoreSystem.User.ProfileResponse;
 
 		@doc("The user who last edited the form.")
-		lastEditor: CoreSystem.User.User;
+		lastEditor: CoreSystem.User.ProfileResponse;
 
-		@doc("(Optional) Deadline for form completion. If not specified, returns null.")
-		deadline?: utcDateTime;
+		@doc("Deadline for form completion.")
+		deadline: utcDateTime;
 
 		@doc("When the form is available to be filled.")
 		publishTime?: utcDateTime;

--- a/src/form/models.tsp
+++ b/src/form/models.tsp
@@ -15,20 +15,12 @@ namespace CoreSystem.Forms {
 
 	@doc("The request body for creating/updating a form.")
 	@example(#{
-		creator: "3c5fa073-7b97-43a3-bc44-ddc98f390a08",
-		lastEditor: "3c5fa073-7b97-43a3-bc44-ddc98f390a08",
 		title: "Enter SDC Form",
 		description: #{ type: "doc", content: #[#{ type: "paragraph", content: #[#{ type: "text", text: "If you want to join us, just fill in this form!" }] }] },
 		messageAfterSubmission: "Thank you for your submission!",
 		visibility: FormVisibility.public,
 	})
 	model FormRequest {
-		@doc("The user who created the form. Required on create; should be omitted on update.")
-		creator?: uuid;
-
-		@doc("The user who last edited the form. Required on create and should be updated on update.")
-		lastEditor?: uuid;
-
 		@doc("The title of the form.")
 		title: string;
 
@@ -129,8 +121,8 @@ namespace CoreSystem.Forms {
 		@doc("The user who last edited the form.")
 		lastEditor: CoreSystem.User.ProfileResponse;
 
-		@doc("Deadline for form completion.")
-		deadline: utcDateTime;
+		@doc("(Optional) Deadline for form completion. If not specified, returns null.")
+		deadline?: utcDateTime;
 
 		@doc("When the form is available to be filled.")
 		publishTime?: utcDateTime;

--- a/src/form/operations.tsp
+++ b/src/form/operations.tsp
@@ -6,19 +6,19 @@ namespace CoreSystem.Forms {
 	@doc("List all existing forms.")
 	@route("/forms")
 	@get
-	op listForms(): Form[];
+	op listForms(): FormResponse[];
 
 	@summary("Get Form")
 	@doc("Get a specific form by its unique identifier. Description fields are returned as ProseMirror JSON for admin editing, with rendered HTML available in `descriptionHtml` for frontend display.")
 	@route("/forms/{formId}")
 	@get
-	op getFormById(@path formId: uuid): Form;
+	op getFormById(@path formId: uuid): FormResponse;
 
 	@summary("Update Form")
 	@doc("Update an existing form by its unique identifier. Description fields in the request body should be sent as ProseMirror JSON from the Tiptap editor.")
 	@route("/forms/{formId}")
 	@patch(#{ implicitOptionality: true })
-	op updateForm(@path formId: uuid, @body updateFormRequest: FormRequest): Form;
+	op updateForm(@path formId: uuid, @body updateFormRequest: FormRequest): FormResponse;
 
 	@summary("Delete Form")
 	@doc("Delete an existing form by its unique identifier.")
@@ -43,7 +43,7 @@ namespace CoreSystem.Forms {
 	@post
 	op archiveForm(@path formId: uuid): {
 		@statusCode statusCode: 200;
-		@body response: Form;
+		@body response: FormResponse;
 	};
 
 	@summary("Unarchive Form")
@@ -52,7 +52,7 @@ namespace CoreSystem.Forms {
 	@post
 	op unarchiveForm(@path formId: uuid): {
 		@statusCode statusCode: 200;
-		@body response: Form;
+		@body response: FormResponse;
 	};
 
 	// === Cover Image Operations ===

--- a/src/inbox/models.tsp
+++ b/src/inbox/models.tsp
@@ -21,7 +21,7 @@ namespace CoreSystem.Inbox {
 		message: InboxFormMessage;
 
 		@doc("The full content of inbox_message.")
-		content?: CoreSystem.Forms.Form;
+		content?: CoreSystem.Forms.FormResponse;
 
 		...UserInboxMessageFilters;
 	}

--- a/src/org/form/operations.tsp
+++ b/src/org/form/operations.tsp
@@ -8,7 +8,7 @@ namespace CoreSystem.Unit {
 	@post
 	op createOrgForm(@path slug: string, @body createFormRequest: CoreSystem.Forms.FormRequest): {
 		@statusCode statusCode: 201;
-		@body form: CoreSystem.Forms.Form;
+		@body form: CoreSystem.Forms.FormResponse;
 	};
 
 	@summary("List Forms by Organization")
@@ -19,6 +19,7 @@ namespace CoreSystem.Unit {
 		@path slug: string,
 
 		@doc("Filter forms by status. If omitted, [DRAFT, PUBLISHED] are returned. Providing any status will override this default.")
-		@query status?: CoreSystem.Forms.FormStatus[] = #[CoreSystem.Forms.FormStatus.draft, CoreSystem.Forms.FormStatus.published]
-	): CoreSystem.Forms.Form[];
+		@query
+		status?: CoreSystem.Forms.FormStatus[] = #[CoreSystem.Forms.FormStatus.draft, CoreSystem.Forms.FormStatus.published],
+	): CoreSystem.Forms.FormResponse[];
 }

--- a/src/user/models.tsp
+++ b/src/user/models.tsp
@@ -3,6 +3,31 @@ namespace CoreSystem.User {
 		user: "USER",
 	}
 
+	@doc("Profile shape returned when embedding a user in other resources.")
+	@example(#{
+		id: "3c5fa073-7b97-43a3-bc44-ddc98f390a08",
+		name: "John Doe",
+		username: "john_doe",
+		avatarUrl: "https://avatars.githubusercontent.com/u/12345678",
+		emails: #["john.doe@example.com", "john@gmail.com"],
+	})
+	model ProfileResponse {
+		@doc("The user's unique identifier.")
+		id: uuid;
+
+		@doc("The user's nickname.")
+		name: string;
+
+		@doc("The user's username, can change, but must be unique across the system.")
+		username: string;
+
+		@doc("Avatar URL of the user.")
+		avatarUrl: string;
+
+		@doc("Email addresses associated with the user.")
+		emails: string[];
+	}
+
 	@example(#{
 		id: "3c5fa073-7b97-43a3-bc44-ddc98f390a08",
 		username: "john_doe",


### PR DESCRIPTION
## Type of changes

- Feature

## Purpose

- Add `creator` and `lastEditor` in form request with UUID
- Adjust `creator` and `lastEditor` to response with `User`