### PR TITLE
[CORE-373] Sort Views Before Order Assertion in Form-Lifecycle Tests

### DIFF
--- a/scenarios/user-journey/form-lifecycle/08-view-management.http
+++ b/scenarios/user-journey/form-lifecycle/08-view-management.http
@@ -379,6 +379,7 @@ GET {{BASE_URL}}/forms/{{formId}}/views
         equal(data.length, 5, 'Should now have 5 views');
 
         // Verify exact order values for each view
+        const views = data.slice().sort((a, b) => a.order - b.order);
         const secondView = views.find(v => v.id === secondViewId);
         const thirdView = views.find(v => v.id === thirdViewId);
         const firstView = views.find(v => v.id === firstViewId);


### PR DESCRIPTION
## Type of changes

- Fix
- Test

## Purpose

- Sort views by `order` before comparing IDs in form-lifecycle view management assertions
- Resolve flaky view order verification after duplication/reorder steps
- Jira: https://clustron.atlassian.net/browse/CORE-373

## Additional Information

- File: `scenarios/user-journey/form-lifecycle/08-view-management.http`
- Adds `const views = data.slice().sort((a, b) => a.order - b.order)` before order value assertions