### PR TITLE
[CORE-375] Enhance Negative Form Lifecycle with Non-Member Login

### DIFF
--- a/scenarios/user-journey/negative-form-lifecycle/.env.example
+++ b/scenarios/user-journey/negative-form-lifecycle/.env.example
@@ -7,3 +7,6 @@ BASE_URL=http://127.0.0.1:4010
 # User ID for internal login (debug authentication)
 # This should be a valid UUID of a user in the system
 LOGIN_USER_ID=00000000-0000-0000-0000-000000000001
+
+# User ID for non-member 403 test (seeded via backend setup.yaml)
+NON_MEMBER_LOGIN_USER_ID=b1c2d3e4-f5a6-7890-abcd-ef1234567890

--- a/scenarios/user-journey/negative-form-lifecycle/02a-form-creation-org-membership-negative.http
+++ b/scenarios/user-journey/negative-form-lifecycle/02a-form-creation-org-membership-negative.http
@@ -11,11 +11,28 @@
 ###
 
 # ============================================
+# Login as non-member user (not in org-403-test)
+# ============================================
+# Org creation adds the global admin as org admin; use a separate user for the 403 test.
+# @name loginNonMember
+# @ref getOrgFor403Test
+POST {{BASE_URL}}/auth/login/internal
+Content-Type: application/json
+
+{
+    "uid": "{{NON_MEMBER_LOGIN_USER_ID}}"
+}
+
+?? status == 200
+
+###
+
+# ============================================
 # Create form under org before user is a member (expect 403)
 # ============================================
 # Uses org from organization-lifecycle: org exists but current user is not a member.
 # @name createFormBeforeMember
-# @ref createOrgFor403Test
+# @ref loginNonMember
 POST {{BASE_URL}}/orgs/{{orgSlugNotMember}}/forms
 Content-Type: application/json
 
@@ -50,10 +67,26 @@ Content-Type: application/json
 ###
 
 # ============================================
+# Re-login as global admin for cleanup
+# ============================================
+# @name adminLoginForCleanup
+# @ref createFormBeforeMember
+POST {{BASE_URL}}/auth/login/internal
+Content-Type: application/json
+
+{
+    "uid": "{{LOGIN_USER_ID}}"
+}
+
+?? status == 200
+
+###
+
+# ============================================
 # Get User Email
 # ============================================
 # @name getUserEmail
-# @ref createFormBeforeMember
+# @ref adminLoginForCleanup
 GET {{BASE_URL}}/users/me
 
 ?? status == 200

--- a/scenarios/user-journey/negative-form-lifecycle/02a-form-creation-org-membership-negative.http
+++ b/scenarios/user-journey/negative-form-lifecycle/02a-form-creation-org-membership-negative.http
@@ -21,7 +21,15 @@ Content-Type: application/json
 
 {
     "title": "Should Be Forbidden",
-    "description": "User not yet a member",
+    "description": {
+        "type": "doc",
+        "content": [
+            {
+                "type": "paragraph",
+                "content": [{ "type": "text", "text": "User not yet a member" }]
+            }
+        ]
+    },
     "visibility": "PUBLIC"
 }
 

--- a/scenarios/user-journey/organization-lifecycle/.env.example
+++ b/scenarios/user-journey/organization-lifecycle/.env.example
@@ -10,3 +10,6 @@ BASE_URL=http://127.0.0.1:4010
 # If you see a 404 "user not found" error, it means the LOGIN_USER_ID is invalid.
 # You must provide a real user UUID from your database/system.
 LOGIN_USER_ID=00000000-0000-0000-0000-000000000001
+
+# User ID for non-member 403 test (seeded via backend setup.yaml)
+NON_MEMBER_LOGIN_USER_ID=b1c2d3e4-f5a6-7890-abcd-ef1234567890


### PR DESCRIPTION
## Type of changes

- Test
- Refactor

## Purpose

- Add `NON_MEMBER_LOGIN_USER_ID` env var for org-membership 403 tests
- Login as non-member user before form creation test (global admin becomes org admin after org creation)
- Re-login as global admin for cleanup steps
- Migrate form description to structured JSON doc format
- Jira: https://clustron.atlassian.net/browse/CORE-375

## Additional Information

- Files:
  - `scenarios/user-journey/negative-form-lifecycle/.env.example`
  - `scenarios/user-journey/negative-form-lifecycle/02a-form-creation-org-membership-negative.http`
  - `scenarios/user-journey/organization-lifecycle/.env.example`
- `NON_MEMBER_LOGIN_USER_ID` is seeded via backend `setup.yaml`